### PR TITLE
Add TravisCI config and README badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - '8.9.4'
+install:
+  - npm install
+script:
+- npm run build

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SUIT
 
-[![Travis][build-badge]][build]
-[![npm package][npm-badge]][npm]
+[![TravisCI][build-badge]][build]
+[![npmjs][npm-badge]][npm]
 [![Coveralls][coveralls-badge]][coveralls]
 
 The Search User Interface Toolkit, or SUIT, is a library for creating search
@@ -71,10 +71,10 @@ use the folllowing commands:
 
 You may find it helpful to make use of NPM’s `link` functionality to facilitate seeing changes you make to the SUIT library code in the front-end application code that uses it, particularly in conjunction with the `npm run start` command. See the NPM documentation for details about doing this.
 
-[build-badge]: https://img.shields.io/travis/mmasi-attivio/suit/master.png?style=flat-square
+[build-badge]: https://travis-ci.org/mmasi-attivio/suit.svg
 [build]: https://travis-ci.org/mmasi-attivio/suit
 
-[npm-badge]: https://img.shields.io/npm/v/npm-package.png?style=flat-square
+[npm-badge]: https://img.shields.io/npm/v/@attivio/suit.svg
 [npm]: https://www.npmjs.org/package/@attivio/suit
 
 [coveralls-badge]: https://coveralls.io/repos/github/mmasi-attivio/suit/badge.svg

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![TravisCI][build-badge]][build]
 [![npmjs][npm-badge]][npm]
-[![Coveralls][coveralls-badge]][coveralls]
 
 The Search User Interface Toolkit, or SUIT, is a library for creating search
 applications on top of the index in an Attivio, Elasticsearch or Solr installation. For more information
@@ -76,6 +75,3 @@ You may find it helpful to make use of NPM’s `link` functionality to facilitat
 
 [npm-badge]: https://img.shields.io/npm/v/@attivio/suit.svg
 [npm]: https://www.npmjs.org/package/@attivio/suit
-
-[coveralls-badge]: https://coveralls.io/repos/github/mmasi-attivio/suit/badge.svg
-[coveralls]: https://coveralls.io/github/mmasi-attivio/suit

--- a/README.md
+++ b/README.md
@@ -77,5 +77,5 @@ You may find it helpful to make use of NPM’s `link` functionality to facilitat
 [npm-badge]: https://img.shields.io/npm/v/npm-package.png?style=flat-square
 [npm]: https://www.npmjs.org/package/@attivio/suit
 
-[coveralls-badge]: https://img.shields.io/coveralls/mmasi-attivio/suit/master.png?style=flat-square
+[coveralls-badge]: https://coveralls.io/repos/github/mmasi-attivio/suit/badge.svg
 [coveralls]: https://coveralls.io/github/mmasi-attivio/suit

--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ use the folllowing commands:
 
 You may find it helpful to make use of NPM’s `link` functionality to facilitate seeing changes you make to the SUIT library code in the front-end application code that uses it, particularly in conjunction with the `npm run start` command. See the NPM documentation for details about doing this.
 
-[build-badge]: https://img.shields.io/travis/user/repo/master.png?style=flat-square
-[build]: https://travis-ci.org/user/repo
+[build-badge]: https://img.shields.io/travis/mmasi-attivio/suit/master.png?style=flat-square
+[build]: https://travis-ci.org/mmasi-attivio/suit
 
 [npm-badge]: https://img.shields.io/npm/v/npm-package.png?style=flat-square
-[npm]: https://www.npmjs.org/package/npm-package
+[npm]: https://www.npmjs.org/package/@attivio/suit
 
-[coveralls-badge]: https://img.shields.io/coveralls/user/repo/master.png?style=flat-square
-[coveralls]: https://coveralls.io/github/user/repo
+[coveralls-badge]: https://img.shields.io/coveralls/mmasi-attivio/suit/master.png?style=flat-square
+[coveralls]: https://coveralls.io/github/mmasi-attivio/suit


### PR DESCRIPTION
- Add TravisCI configuration
- Modifiy the pre-existing generic badges to point to the real URLs

Note that if this PR is accepted, it should _**not**_ be merged into master as-is -- the urls are set to point to my fork of the repo so it won't reflect reality. This is more of a POC to show what the badges will look like.