### PR TITLE
Issue-5: Use `displayName` instead of class `name` for setting default properties

### DIFF
--- a/src/components/Configurable.js
+++ b/src/components/Configurable.js
@@ -39,7 +39,8 @@ function Configurable(WrappedComponent: React.Component): React.Component {
       const filled = Object.assign({}, props);
       if (this.context && this.context.configuration) {
         propKeys.forEach((property: string) => {
-          filled[property] = this.context.configuration.get(WrappedComponent.name, property, props[property]);
+          const name = WrappedComponent.displayName || WrappedComponent.name;
+          filled[property] = this.context.configuration.get(name, property, props[property]);
         });
       }
       this.setState({

--- a/src/components/Masthead.js
+++ b/src/components/Masthead.js
@@ -64,6 +64,8 @@ class Masthead extends React.Component<MastheadDefaultProps, MastheadProps, Mast
     searcher: PropTypes.any,
   };
 
+  static displayName = 'Masthead';
+
   static defaultProps: MastheadDefaultProps = {
     logoUri: 'img/attivio-logo-reverse.png',
     logoAlt: 'Attivio Home',

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -82,6 +82,8 @@ class SearchBar extends React.Component<SearchBarDefaultProps, SearchBarProps, S
     searcher: PropTypes.any,
   };
 
+  static displayName = 'SearchBar';
+
   static defaultProps: SearchBarDefaultProps = {
     inMasthead: false,
     placeholder: 'Search\u2026',

--- a/src/components/Searcher.js
+++ b/src/components/Searcher.js
@@ -257,6 +257,8 @@ the offset to 0, and , if there's a previous search, perform a new one (and, onl
 
  */
 class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, SearcherState> {
+  static displayName = 'Searcher';
+
   static STAR_COLON_STAR = '*:*';
 
   static defaultProps = {


### PR DESCRIPTION
JS prod minimizers (like UglifyJS) will mangle the class names, so using the `name` attribute is dangerous. Currently, searchui-frontend breaks and can't use certain properties (i.e. `businessCenterProfile`). This change (and future addition of `displayName` static attributes, allows proper production optimizations.

Other components wrapped by `Configurable` should get `displayName` attributes in the future as it also enhances React debugability in production.