### PR TITLE
PLAT-41732: For IE 11, use the handler onInput instead of onChange fo…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@attivio/suit",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@attivio/suit",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "description": "Attivio SUIT, the Search UI Toolkit, is a library for creating search clients for searching the Attivio platform.",
   "keywords": [
     "Attivio",

--- a/src/components/AutoCompleteInput.js
+++ b/src/components/AutoCompleteInput.js
@@ -36,6 +36,8 @@ type AutoCompleteInputState = {
   queryValue: string;
 };
 
+const isIE11 = !(window.ActiveXObject) && 'ActiveXObject' in window;
+
 export default class AutoCompleteInput extends React.Component<AutoCompleteInputDefaultProps, AutoCompleteInputProps, AutoCompleteInputState> { // eslint-disable-line max-len
   static defaultProps = {
     id: 'autocomplete',
@@ -50,6 +52,10 @@ export default class AutoCompleteInput extends React.Component<AutoCompleteInput
 
   // Start looking for autocomplete values when there are at least 3 characters in the input field
   static AUTOCOMPLETE_THRESHOLD = 2;
+
+  static getInputOnChangeProps(handler) {
+    return isIE11 ? { onInput: handler } : { onChange: handler };
+  }
 
   constructor(props: AutoCompleteInputProps) {
     super(props);
@@ -207,7 +213,7 @@ export default class AutoCompleteInput extends React.Component<AutoCompleteInput
             className={this.props.className}
             style={this.props.style}
             disabled={this.props.disabled}
-            onChange={this.handleChange}
+            {...AutoCompleteInput.getInputOnChangeProps(this.handleChange)}
             onKeyDown={this.doKeyPress}
           />
           <Dropdown.Toggle


### PR DESCRIPTION
…r the AutoCompleteInput component to avoid slowness