### PR TITLE
issue-27: Add Facet Search

### DIFF
--- a/src/components/Facet.js
+++ b/src/components/Facet.js
@@ -42,12 +42,6 @@ type FacetProps = {
   bordered: boolean;
   /** Controls the colors used to show various entity types (the value can be any valid CSS color) */
   entityColors: Map<string, string>;
-  /** Should the search bar be exposed for list facets */
-  showSearchBar: boolean;
-  /** Should the export button be available for the facet values for list facets */
-  showExportButton: boolean;
-  /** The label for the export button */
-  exportButtonLabel: string;
 }
 
 type FacetDefaultProps = {

--- a/src/components/Facet.js
+++ b/src/components/Facet.js
@@ -16,6 +16,7 @@ import TagCloudFacetContents from './TagCloudFacetContents';
 import TimeSeriesFacetContents from './TimeSeriesFacetContents';
 import SentimentFacetContents from './SentimentFacetContents';
 import MapFacetContents from './MapFacetContents';
+import FacetSearchBar from './FacetSearchBar';
 
 export type FacetType = 'barchart' | 'columnchart' | 'piechart' | 'barlist' |
   'tagcloud' | 'timeseries' | 'list' | 'sentiment' | 'geomap' |
@@ -41,6 +42,12 @@ type FacetProps = {
   bordered: boolean;
   /** Controls the colors used to show various entity types (the value can be any valid CSS color) */
   entityColors: Map<string, string>;
+  /** Should the search bar be exposed for list facets */
+  showSearchBar: boolean;
+  /** Should the export button be available for the facet values for list facets */
+  showExportButton: boolean;
+  /** The label for the export button */
+  exportButtonLabel: string;
 }
 
 type FacetDefaultProps = {
@@ -186,9 +193,18 @@ export default class Facet extends React.Component<FacetDefaultProps, FacetProps
           facetContents = <MapFacetContents buckets={this.props.facet.buckets} addFacetFilter={this.addFacetFilter} />;
           break;
         case 'list':
-        default:
-          facetContents = <MoreListFacetContents buckets={this.props.facet.buckets} addFacetFilter={this.addFacetFilter} />;
+        default: {
+          const childProps = <MoreListFacetContents buckets={this.props.facet.buckets} addFacetFilter={this.addFacetFilter} />;
+          facetContents = (
+            <FacetSearchBar
+              childProps={childProps}
+              name={this.props.facet.field}
+              label={this.props.facet.label}
+              addFacetFilter={this.addFacetFilter}
+            />
+          );
           break;
+        }
       }
     } else {
       facetContents = <span className="none">No values for this facet.</span>;

--- a/src/components/Facet.js
+++ b/src/components/Facet.js
@@ -188,14 +188,15 @@ export default class Facet extends React.Component<FacetDefaultProps, FacetProps
           break;
         case 'list':
         default: {
-          const childProps = <MoreListFacetContents buckets={this.props.facet.buckets} addFacetFilter={this.addFacetFilter} />;
           facetContents = (
             <FacetSearchBar
               childProps={childProps}
               name={this.props.facet.field}
               label={this.props.facet.label}
               addFacetFilter={this.addFacetFilter}
-            />
+            >
+              <MoreListFacetContents buckets={this.props.facet.buckets} addFacetFilter={this.addFacetFilter} />
+            </FacetSearchBar>
           );
           break;
         }

--- a/src/components/Facet.js
+++ b/src/components/Facet.js
@@ -190,7 +190,6 @@ export default class Facet extends React.Component<FacetDefaultProps, FacetProps
         default: {
           facetContents = (
             <FacetSearchBar
-              childProps={childProps}
               name={this.props.facet.field}
               label={this.props.facet.label}
               addFacetFilter={this.addFacetFilter}

--- a/src/components/FacetSearchBar.js
+++ b/src/components/FacetSearchBar.js
@@ -1,0 +1,315 @@
+// @flow
+import React from 'react';
+import PropTypes from 'prop-types';
+import MenuItem from 'react-bootstrap/lib/MenuItem';
+import Configurable from './Configurable';
+import SimpleQueryRequest from '../api/SimpleQueryRequest';
+
+type SearchBarProps = {
+  placeholder: string;
+  /** The label to show on the search button. Defaults to "Go". */
+  buttonLabel: string;
+  name: string;
+  /** Callback to add a filter for this facet. */
+  addFacetFilter: (bucket: SearchFacetBucket) => void;
+  maxValues: number;
+  childProps: Object | null;
+  showSearchBar: boolean;
+  showExportButton: boolean;
+};
+
+type SearchBarDefaultProps = {
+  placeholder: string;
+  buttonLabel: string;
+  name: string;
+    /** Callback to add a filter for this facet. */
+  addFacetFilter: (bucket: SearchFacetBucket) => void;
+  maxValues: number;
+  showSearchBar: boolean;
+  showExportButton: boolean;
+};
+
+type SearchBarState = {
+  query: string,
+  recognizing: boolean,
+  suggestions: Array<Object>,
+  facetValue: string,
+}
+
+/**
+ * Component to include in the Masthead for entering the query
+ * to use when searching. Must be inside a Searcher component.
+ */
+class FacetSearchBar extends React.Component<SearchBarDefaultProps, SearchBarState, SearchBarProps> {
+  static contextTypes = {
+    searcher: PropTypes.any,
+  };
+
+  static defaultProps: SearchBarDefaultProps = {
+    placeholder: 'Search Facet Values',
+    buttonLabel: 'Search',
+    name: '*',
+    addFacetFilter: (bucket) => {},
+    maxValues: 5,
+    showSearchBar: true,
+    showExportButton: true,
+  };
+
+  static convertArrayOfObjectsToCSV(args) {
+    let result = null;
+    let ctr = null;
+    let keys = null;
+    let columnDelimiter = null;
+    let lineDelimiter = null;
+    let data = null;
+
+    data = args.data || null;
+    if (data == null || !data.length) {
+      return null;
+    }
+
+    columnDelimiter = args.columnDelimiter || ',';
+    lineDelimiter = args.lineDelimiter || '\n';
+
+    keys = Object.keys(data[0]);
+
+    result = '';
+    result += keys.join(columnDelimiter);
+    result += lineDelimiter;
+
+    data.forEach((item) => {
+      ctr = 0;
+      if (keys && keys.length > 0) {
+        keys.forEach((key) => {
+          if (ctr > 0) result += columnDelimiter;
+
+          result += item[key];
+          ctr += 1;
+        });
+        result += lineDelimiter;
+      }
+    });
+
+    return result;
+  }
+
+  constructor(props: SearchBarProps) {
+    super(props);
+    this.state = {
+      query: '',
+      recognizing: false,
+      suggestions: [],
+      facetValue: '',
+    };
+    (this: any).doKeyPress = this.doKeyPress.bind(this);
+    (this: any).doSearch = this.doSearch.bind(this);
+    (this: any).queryChanged = this.queryChanged.bind(this);
+    (this: any).updateQuery = this.updateQuery.bind(this);
+    (this: any).addFilter = this.addFilter.bind(this);
+    (this: any).handleSearchResults = this.handleSearchResults.bind(this);
+  }
+
+  state: SearchBarState;
+
+  getSuggestionList() {
+    if (!this.state.suggestions || this.state.suggestions.length === 0) {
+      return null;
+    }
+    let suggestionsAdded = 0;
+    const contents = this.state.suggestions.map((suggestion: string, index: number) => {
+      let include = suggestion.displayLabel().length >= this.state.query.length;
+      include = include && suggestion.displayLabel().toLowerCase().indexOf(this.state.query.toLowerCase()) !== -1;
+      let returnVal = '';
+      if (include && suggestionsAdded < this.props.maxValues) {
+        suggestionsAdded += 1;
+        returnVal = (
+          <button
+            className={'facet-suggestion'}
+            key={suggestionsAdded}
+            onClick={() => { return this.addFilter(index); }}
+            style={{ width: '300px', textAlign: 'left', borderWidth: '0px', backgroundColor: '#FFFFFF' }}
+          >
+            <MenuItem eventKey={index} key={suggestionsAdded} onSelect={this.addFilter} tabIndex={index}>
+              {`${suggestion.displayLabel()} (${suggestion.count})`}
+            </MenuItem>
+          </button>);
+      }
+      return returnVal;
+    });
+    if (contents.length > 0) {
+      return (
+        <div className={'facet-suggestion'} style={{ width: '300px', border: '1px solid #D2D2D2', passingTop: '11px' }}>
+          <ul role="menu">
+            {contents}
+          </ul>
+        </div>
+      );
+    }
+    return null;
+  }
+
+  getAllFacetValues(callback) {
+    function localCallback(qr: ?QueryResponse, error: ?string) {
+      if (qr) {
+        const facets = qr.facets[0].buckets;
+        const response = [];
+        facets.map((facet: Object) => {
+          response.push({ 'Facet Value': facet.displayLabel(), 'Document Count': facet.count });
+          return '';
+        });
+        callback(response);
+      } else if (error) {
+        // Failed!
+      }
+      return [];
+    }
+    this.doConfiguredSearch('*', -1, localCallback, this.context.searcher);
+  }
+
+  addFilter(eventKey) {
+    this.props.addFacetFilter(this.state.suggestions[eventKey]);
+    this.setState({ suggestions: [], query: '' });
+  }
+
+  handleSearchResults(response: ?QueryResponse, error: ?string) {
+    if (response) {
+      const facets = response.facets[0].buckets;
+      this.setState({ suggestions: facets });
+    } else if (error) {
+      // Failed!
+      this.setState({
+        suggestions: undefined,
+        error,
+      });
+    }
+  }
+
+  doConfiguredSearch(queryTerm: string, maxBuckets: number, callback, searcher) {
+    if (searcher) {
+      const searchTerm = searcher.state.query;
+      const simpleQR = new SimpleQueryRequest();
+      simpleQR.query = searchTerm;
+      simpleQR.facets = [`${this.props.name}(maxBuckets=${maxBuckets})`];
+      simpleQR.facetFilters = searcher.state.facetFilters;
+      simpleQR.filters = [];
+      if (searcher.getQueryRequest().filters && searcher.getQueryRequest().filters.length > 0) {
+        Array.prototype.push.apply(simpleQR.filters, searcher.getQueryRequest().filters);
+      }
+      simpleQR.filters.push(`${this.props.name}:${queryTerm}`);
+      simpleQR.rows = 0;
+      simpleQR.queryLanguage = 'simple';
+      simpleQR.workflow = searcher.getQueryRequest().workflow;
+
+      searcher.doCustomSearch(simpleQR, callback);
+    }
+  }
+
+  doSearch() {
+    const callback = this.handleSearchResults;
+    this.doConfiguredSearch(`${this.state.facetValue}*`, this.props.maxValues * 2, callback, this.context.searcher);
+  }
+
+  queryChanged(e: Event) {
+    if (e.target instanceof HTMLInputElement) {
+      const newQuery = e.target.value;
+      this.setState({ facetValue: newQuery, query: newQuery });
+    }
+  }
+
+  updateQuery(newQuery: string, doSearch: boolean = false) {
+    if (doSearch) {
+      this.setState({ facetValue: newQuery, query: newQuery }, this.doSearch());
+    } else {
+      this.setState({ facetValue: newQuery, query: newQuery });
+    }
+  }
+
+  downloadCSV(args) {
+    const callback = (data) => {
+      let csv = this.convertArrayOfObjectsToCSV({ data });
+      if (csv == null) return;
+
+      const filename = args.filename || `${this.props.name}_facet_values.csv`;
+
+      if (!csv.match(/^data:text\/csv/i)) {
+        csv = `data:text/csv;charset=utf-8,${csv}`;
+      }
+      const encodedData = encodeURI(csv);
+
+      const link = document.createElement('a');
+      link.setAttribute('href', encodedData);
+      link.setAttribute('download', filename);
+      link.click();
+    };
+    this.getAllFacetValues(callback);
+  }
+
+  doKeyPress(e: Event) {
+    // If the user presses enter, do the search
+    if (e.target instanceof HTMLInputElement) {
+      if (e.keyCode === 13) {
+        this.doSearch();
+      }
+    }
+  }
+
+  submitButton: ?HTMLButtonElement;
+  advancedMenuItem: ?HTMLSpanElement;
+  simpleMenuItem: ?HTMLSpanElement;
+
+  render() {
+    const additionalContent = this.props.childProps ? this.props.childProps : '';
+    const containerClass = 'attivio-globalmast-search-container';
+    const inputClass = 'form-control attivio-globalmast-search-input facet-search-bar';
+    const query = this.state.query;
+    const placeholder = this.props.placeholder;
+    const suggestionList = this.getSuggestionList();
+    const inputComponent = this.props.showSearchBar ? (
+      <div className="attivio-globalmast-search" role="search" style={{ display: 'inline-block' }}>
+        <div className="form-group">
+            <input
+              type="search"
+              className={inputClass}
+              placeholder={placeholder}
+              onChange={this.queryChanged}
+              onKeyDown={this.doKeyPress}
+              value={query}
+              style={{ minWidth: '300px' }}
+            />
+            <button
+              type="submit"
+              className="btn attivio-globalmast-search-submit"
+              onClick={this.doSearch}
+              style={{ height: '25px' }}
+              ref={(c) => { this.submitButton = c; }}
+            >
+              {this.props.buttonLabel}
+            </button>
+          </div>
+        {suggestionList}
+      </div>) : '';
+
+    const buttonContent = this.props.showExportButton ? (        
+      <div>
+          <button
+            id={this.props.name}
+            className="btn attivio-globalmast-search-submit"
+            style={{ height: '25px', position: 'relative' }}
+            href="#"
+            onClick={() => { return this.downloadCSV({}); }}
+          >
+            Export to CSV
+          </button>
+        </div>) : '';
+    
+    return (
+      <div className={containerClass}>
+        { inputComponent }
+        { additionalContent }
+        {} buttonContent }
+      </div>
+    );
+  }
+}
+
+export default Configurable(FacetSearchBar);

--- a/src/components/FacetSearchBar.js
+++ b/src/components/FacetSearchBar.js
@@ -40,7 +40,7 @@ type SearchBarState = {
  * Component to include in the Masthead for entering the query
  * to use when searching. Must be inside a Searcher component.
  */
-class FacetSearchBar extends React.Component<SearchBarDefaultProps, SearchBarState, SearchBarProps> {
+class FacetSearchBar extends React.Component<SearchBarDefaultProps, SearchBarProps, SearchBarState> {
   static contextTypes = {
     searcher: PropTypes.any,
   };
@@ -49,7 +49,7 @@ class FacetSearchBar extends React.Component<SearchBarDefaultProps, SearchBarSta
     placeholder: 'Search Facet Values',
     buttonLabel: 'Search',
     name: '*',
-    addFacetFilter: (bucket) => {},
+    addFacetFilter: (bucket) => { return bucket.label; },
     maxValues: 5,
     showSearchBar: true,
     showExportButton: true,
@@ -267,46 +267,46 @@ class FacetSearchBar extends React.Component<SearchBarDefaultProps, SearchBarSta
     const inputComponent = this.props.showSearchBar ? (
       <div className="attivio-globalmast-search" role="search" style={{ display: 'inline-block' }}>
         <div className="form-group">
-            <input
-              type="search"
-              className={inputClass}
-              placeholder={placeholder}
-              onChange={this.queryChanged}
-              onKeyDown={this.doKeyPress}
-              value={query}
-              style={{ minWidth: '300px' }}
-            />
-            <button
-              type="submit"
-              className="btn attivio-globalmast-search-submit"
-              onClick={this.doSearch}
-              style={{ height: '25px' }}
-              ref={(c) => { this.submitButton = c; }}
-            >
-              {this.props.buttonLabel}
-            </button>
-          </div>
+          <input
+            type="search"
+            className={inputClass}
+            placeholder={placeholder}
+            onChange={this.queryChanged}
+            onKeyDown={this.doKeyPress}
+            value={query}
+            style={{ minWidth: '300px' }}
+          />
+          <button
+            type="submit"
+            className="btn attivio-globalmast-search-submit"
+            onClick={this.doSearch}
+            style={{ height: '25px' }}
+            ref={(c) => { this.submitButton = c; }}
+          >
+            {this.props.buttonLabel}
+          </button>
+        </div>
         {suggestionList}
       </div>) : '';
 
-    const buttonContent = this.props.showExportButton ? (        
+    const buttonContent = this.props.showExportButton ? (
       <div>
-          <button
-            id={this.props.name}
-            className="btn attivio-globalmast-search-submit"
-            style={{ height: '25px', position: 'relative' }}
-            href="#"
-            onClick={() => { return this.downloadCSV({}); }}
-          >
+        <button
+          id={this.props.name}
+          className="btn attivio-globalmast-search-submit"
+          style={{ height: '25px', position: 'relative' }}
+          href="#"
+          onClick={() => { return this.downloadCSV({}); }}
+        >
             Export to CSV
           </button>
-        </div>) : '';
-    
+      </div>) : '';
+
     return (
       <div className={containerClass}>
         { inputComponent }
         { additionalContent }
-        {} buttonContent }
+        { buttonContent }
       </div>
     );
   }

--- a/src/components/FacetSearchBar.js
+++ b/src/components/FacetSearchBar.js
@@ -1,6 +1,8 @@
 // @flow
 import React from 'react';
+import type { Children } from 'react';
 import PropTypes from 'prop-types';
+
 import MenuItem from 'react-bootstrap/lib/MenuItem';
 import Configurable from './Configurable';
 import SimpleQueryRequest from '../api/SimpleQueryRequest';
@@ -20,7 +22,7 @@ type FacetSearchBarProps = {
   /** Max number of matching facet values to show */
   maxValues: number;
   /** Content to show for the actual facet stuff (typically a ListFacetContents) */
-  childProps: Object | null;
+  children: Children;
   /**
    * Whether the export button should be shown to allow exporting all the facet
    * values as a CSV file
@@ -277,7 +279,6 @@ class FacetSearchBar extends React.Component<FacetSearchBarDefaultProps, FacetSe
   }
 
   render() {
-    const additionalContent = this.props.childProps ? this.props.childProps : '';
     const containerClass = 'attivio-globalmast-search-container';
     const inputClass = 'form-control attivio-globalmast-search-input facet-search-bar';
     const query = this.state.query;
@@ -301,10 +302,10 @@ class FacetSearchBar extends React.Component<FacetSearchBarDefaultProps, FacetSe
             onClick={this.doSearch}
             style={{ height: '25px' }}
           >
-            { this.props.buttonLabel }
+            {this.props.buttonLabel}
           </button>
         </div>
-        { suggestionList }
+        {suggestionList}
       </div>) : '';
 
     const buttonContent = this.props.showExportButton ? (
@@ -316,15 +317,15 @@ class FacetSearchBar extends React.Component<FacetSearchBarDefaultProps, FacetSe
           href="#"
           onClick={() => { return this.downloadCSV({}); }}
         >
-          { this.props.exportButtonLabel }
+          {this.props.exportButtonLabel}
         </button>
       </div>) : '';
 
     return (
       <div className={containerClass}>
-        { inputComponent }
-        { additionalContent }
-        { buttonContent }
+        {inputComponent}
+        {this.props.children}
+        {buttonContent}
       </div>
     );
   }


### PR DESCRIPTION
Creates a new component called `FacetSearchBar`, which can wrap a facet component (e.x. `MoreListFacetContents`), with the ability to display a Search Bar above the facet list, and an export button below. 

The Search Bar allows users to search for values outside of the top n displayed in the list (like if they want to filter to news showing a specific company, but that company isn't in the top buckets shown in the list). They can click the search result for the facet to apply it as a filter. 

The export button allows users to download a CSV containing a list of all facet values for that facet, and the count of docs that match that facet value. 

Here is an exmaple screenshot:
<img width="196" alt="example" src="https://user-images.githubusercontent.com/26821306/43103061-e9a2f2fe-8e9a-11e8-9e02-60004f887004.PNG">

The `Facet` component was also modified, to wrap the MoreListFacetContents component with the FacetSearchBar component. 

Note that users can configure the `FacetSearchBar`. Here is a sample configuration that can be placed in configuration.properties.js:
```javascript
 FacetSearchBar: {
	// SEARCH BAR CONGIGS
	// Should there be a Facet Search Bar exposed to end users 
	showSearchBar: true,
	// The placeholder for the search bar
        placeholder: 'Search Facet Values',
	// The label on the 'Search' button
        buttonLabel: 'Search',
	// Max number of matching facet values to show
	maxValues: 5,
	// EXPORT CONFIGS
	// Should there be an export button exposed to end users
	showExportButton: true,
	// The label for the export button for exporting results to a CSV
	exportButtonLabel: 'Export',
  },
