### PR TITLE
issue-29: Add Sentiment Tag Cloud

### DIFF
--- a/docs/style/bootstrap/attivio-search-results.less
+++ b/docs/style/bootstrap/attivio-search-results.less
@@ -740,6 +740,87 @@
 	font-weight: 700;
 }
 
+/* Sentiment Cloud */
+.attivio-sentiment-cloud {
+	display: flex;
+	flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+}
+.attivio-sentiment-cloud li {
+	display: inline-block;
+	margin: 0.125rem;
+	padding: 0.4375rem;
+	transition: all .2s ease-in-out;
+}
+.attivio-sentiment-cloud li a:hover {
+    text-decoration: none;
+}
+.attivio-sentiment-cloud li:hover,
+.attivio-sentiment-cloud li:focus {
+	transform: scale(1.1);
+}
+.attivio-sentiment-cloud-level-1,
+.attivio-facet li .attivio-sentiment-cloud-level-1 {
+	color: #ff3232;
+	font-size: 40px;
+	font-weight: 700;
+}
+.attivio-sentiment-cloud-level-2,
+.attivio-facet li .attivio-sentiment-cloud-level-2 {
+	color: #ff3232;
+	font-size: 35px;
+	font-weight: 600;
+}
+.attivio-sentiment-cloud-level-3,
+.attivio-facet li .attivio-sentiment-cloud-level-3 {
+	color: #ff4c4c;
+	font-size: 25px;
+	font-weight: bold;
+}
+.attivio-sentiment-cloud-level-4,
+.attivio-facet li .attivio-sentiment-cloud-level-4 {
+	color: #ff6666;
+	font-size: 20px;
+	font-weight: bold;
+}
+.attivio-sentiment-cloud-level-5,
+.attivio-facet li .attivio-sentiment-cloud-level-5 {
+	color: #ff7f7f;
+	font-size: 15px;
+	font-weight: bold;
+}
+.attivio-sentiment-cloud-level-6,
+.attivio-facet li .attivio-sentiment-cloud-level-6 {
+	color: #4ca64c;
+	font-size: 15px;
+	font-weight: bold;
+}
+.attivio-sentiment-cloud-level-7,
+.attivio-facet li .attivio-sentiment-cloud-level-7 {
+	color: #329932;
+	font-size: 20px;
+	font-weight: bold;
+}
+.attivio-sentiment-cloud-level-8,
+.attivio-facet li .attivio-sentiment-cloud-level-8 {
+	color: #329932;
+	font-size: 25px;
+	font-weight: bold;
+}
+.attivio-sentiment-cloud-level-9,
+.attivio-facet li .attivio-sentiment-cloud-level-9 {
+	color: #329932;
+	font-size: 35px;
+	font-weight: 600;
+}
+.attivio-sentiment-cloud-level-10,
+.attivio-facet li .attivio-sentiment-cloud-level-10 {
+	color: #329932;
+	font-size: 40px;
+	font-weight: 700;
+}
+
 /* Debugger */
 .attivio-search-result-debugger dt {
 	color: #767676;

--- a/src/components/Facet.js
+++ b/src/components/Facet.js
@@ -25,6 +25,10 @@ export type FacetType = 'barchart' | 'columnchart' | 'piechart' | 'barlist' |
 type FacetProps = {
   /** The facet to display. */
   facet: SearchFacet;
+  /** The facet for positive key phrases used in Sentiment TagCloud */
+  positiveKeyphrases?: SearchFacet;
+  /** The facet for negative key phrases used in Sentiment TagCloud */
+  negativeKeyphrases?: SearchFacet;
   /** The way the facet information should be displayed. Defaults to 'list' */
   type: FacetType;
   /**
@@ -42,11 +46,6 @@ type FacetProps = {
   bordered: boolean;
   /** Controls the colors used to show various entity types (the value can be any valid CSS color) */
   entityColors: Map<string, string>;
-
-
-  /** The facets for positive and negative keyphrases used in Sentiment TagCloud */
-  positiveKeyphrases: SearchFacet;
-  negativeKeyphrases: SearchFacet;
 }
 
 type FacetDefaultProps = {
@@ -85,10 +84,10 @@ export default class Facet extends React.Component<FacetDefaultProps, FacetProps
     let bucketLabel;
     if (this.props.positiveKeyphrases || this.props.negativeKeyphrases) {
       bucketLabel = customBucketLabel || bucket.value.displayLabel();
-      if (bucket.sentiment === 'positive') {
-        this.context.searcher.addFacetFilter(this.props.positiveKeyphrases.findLabel(), bucketLabel, bucket.filter);
-      } else if (bucket.sentiment === 'negative') {
-        this.context.searcher.addFacetFilter(this.props.negativeKeyphrases.findLabel(), bucketLabel, bucket.filter);
+      if (bucket.sentiment === 'positive' && this.props.positiveKeyphrases) {
+        this.context.searcher.addFacetFilter(this.props.positiveKeyphrases.findLabel(), bucketLabel, bucket.value.filter);
+      } else if (bucket.sentiment === 'negative' && this.props.negativeKeyphrases) {
+        this.context.searcher.addFacetFilter(this.props.negativeKeyphrases.findLabel(), bucketLabel, bucket.value.filter);
       }
     } else if (this.props.facet) {
       bucketLabel = customBucketLabel || bucket.displayLabel();
@@ -131,7 +130,7 @@ export default class Facet extends React.Component<FacetDefaultProps, FacetProps
     }
 
     let facetContents;
-    if (this.props.positiveKeyphrases && this.props.negativeKeyphrases) {
+    if (this.props.type === 'sentimenttagcloud' && this.props.positiveKeyphrases && this.props.negativeKeyphrases) {
       if (this.props.positiveKeyphrases.buckets && this.props.negativeKeyphrases.buckets) {
         if (this.props.positiveKeyphrases.buckets.length > 0 || this.props.negativeKeyphrases.buckets.length > 0) {
           facetContents = (

--- a/src/components/Facet.js
+++ b/src/components/Facet.js
@@ -16,6 +16,7 @@ import TagCloudFacetContents from './TagCloudFacetContents';
 import TimeSeriesFacetContents from './TimeSeriesFacetContents';
 import SentimentFacetContents from './SentimentFacetContents';
 import MapFacetContents from './MapFacetContents';
+import SentimentTagCloudFacetContents from './SentimentTagCloudFacetContents';
 
 export type FacetType = 'barchart' | 'columnchart' | 'piechart' | 'barlist' |
   'tagcloud' | 'timeseries' | 'list' | 'sentiment' | 'geomap' |
@@ -41,6 +42,11 @@ type FacetProps = {
   bordered: boolean;
   /** Controls the colors used to show various entity types (the value can be any valid CSS color) */
   entityColors: Map<string, string>;
+
+
+  /** The facets for positive and negative keyphrases used in Sentiment TagCloud */
+  positiveKeyphrases: SearchFacet;
+  negativeKeyphrases: SearchFacet;
 }
 
 type FacetDefaultProps = {
@@ -75,9 +81,19 @@ export default class Facet extends React.Component<FacetDefaultProps, FacetProps
     (this: any).addTimeSeriesFilter = this.addTimeSeriesFilter.bind(this);
   }
 
-  addFacetFilter(bucket: SearchFacetBucket, customBucketLabel: ?string) {
-    const bucketLabel = customBucketLabel || bucket.displayLabel();
-    this.context.searcher.addFacetFilter(this.props.facet.findLabel(), bucketLabel, bucket.filter);
+  addFacetFilter(bucket: SearchFacetBucket | any, customBucketLabel: ?string) {
+    let bucketLabel;
+    if (this.props.positiveKeyphrases || this.props.negativeKeyphrases) {
+      bucketLabel = customBucketLabel || bucket.value.displayLabel();
+      if (bucket.sentiment === 'positive') {
+        this.context.searcher.addFacetFilter(this.props.positiveKeyphrases.findLabel(), bucketLabel, bucket.filter);
+      } else if (bucket.sentiment === 'negative') {
+        this.context.searcher.addFacetFilter(this.props.negativeKeyphrases.findLabel(), bucketLabel, bucket.filter);
+      }
+    } else if (this.props.facet) {
+      bucketLabel = customBucketLabel || bucket.displayLabel();
+      this.context.searcher.addFacetFilter(this.props.facet.findLabel(), bucketLabel, bucket.filter);
+    }
   }
 
   /**
@@ -109,10 +125,28 @@ export default class Facet extends React.Component<FacetDefaultProps, FacetProps
 
   render() {
     const facetColors = this.props.entityColors;
-    const facetColor = facetColors.has(this.props.facet.field) ? facetColors.get(this.props.facet.field) : null;
+    let facetColor;
+    if (this.props.facet) {
+      facetColor = facetColors.has(this.props.facet.field) ? facetColors.get(this.props.facet.field) : null;
+    }
 
     let facetContents;
-    if (this.props.facet.buckets && this.props.facet.buckets.length > 0) {
+    if (this.props.positiveKeyphrases && this.props.negativeKeyphrases) {
+      if (this.props.positiveKeyphrases.buckets && this.props.negativeKeyphrases.buckets) {
+        if (this.props.positiveKeyphrases.buckets.length > 0 || this.props.negativeKeyphrases.buckets.length > 0) {
+          facetContents = (
+            <SentimentTagCloudFacetContents
+              positiveBuckets={this.props.positiveKeyphrases.buckets}
+              negativeBuckets={this.props.negativeKeyphrases.buckets}
+              maxBuckets={this.props.maxBuckets}
+              addFacetFilter={this.addFacetFilter}
+            />
+          );
+        }
+      }
+    }
+
+    if (this.props.facet && this.props.facet.buckets && this.props.facet.buckets.length > 0) {
       switch (this.props.type) {
         case 'barchart':
           facetContents = facetColor ? (
@@ -126,7 +160,7 @@ export default class Facet extends React.Component<FacetDefaultProps, FacetProps
               buckets={this.props.facet.buckets}
               addFacetFilter={this.addFacetFilter}
             />
-          );
+            );
           break;
         case 'columnchart':
           facetContents = facetColor ? (
@@ -142,7 +176,7 @@ export default class Facet extends React.Component<FacetDefaultProps, FacetProps
               addFacetFilter={this.addFacetFilter}
               columns
             />
-          );
+            );
           break;
         case 'piechart':
           facetContents = (
@@ -190,15 +224,18 @@ export default class Facet extends React.Component<FacetDefaultProps, FacetProps
           facetContents = <MoreListFacetContents buckets={this.props.facet.buckets} addFacetFilter={this.addFacetFilter} />;
           break;
       }
-    } else {
+    } else if (!this.props.positiveKeyphrases && !this.props.negativeKeyphrases) {
       facetContents = <span className="none">No values for this facet.</span>;
     }
 
     // Prefer the display name but fall back to the name field (note special case for geomaps
     // where we always use the label "Map").
-    const label = this.props.type === 'geomap' ? 'Map' : this.props.facet.findLabel();
+    let label;
+    if (this.props.facet) {
+      label = this.props.type === 'geomap' ? 'Map' : this.props.facet.findLabel();
+    }
 
-    if (this.props.collapse) {
+    if (this.props.facet && this.props.collapse) {
       const collapsed = this.props.facet.buckets.length === 0;
       return (
         <CollapsiblePanel title={label} id={`facet-${this.props.facet.field}`} collapsed={collapsed}>

--- a/src/components/SentimentTagCloud.js
+++ b/src/components/SentimentTagCloud.js
@@ -66,7 +66,7 @@ export default class SentimentTagCloud extends React.Component<SentimentTagCloud
       const outMax = 5;
       return (((num - inMin) * (outMin - outMax)) / (inMax - inMin)) + outMax;
     }
-    return null;
+    return -1;
   }
 
   static getAdjustedValue(value: number, max: number, sentiment: string): number {

--- a/src/components/SentimentTagCloud.js
+++ b/src/components/SentimentTagCloud.js
@@ -1,0 +1,130 @@
+// @flow
+
+import React from 'react';
+
+export class SentimentTagCloudValue {
+  /** The string to display in the list. */
+  label: string;
+  /** The value for this item. */
+  value: number;
+  /** The sentiment for this item. */
+  sentiment: string;
+
+  constructor(label: string, value: number, sentiment: string) {
+    this.label = label;
+    this.value = value;
+    this.sentiment = sentiment;
+  }
+}
+
+type SentimentTagCloudProps = {
+  /** The names and values for positive keyphrases to display. */
+  positiveTags: Array<SentimentTagCloudValue>;
+  /** The names and values for negative keyphrases to display. */
+  negativeTags: Array<SentimentTagCloudValue>;
+  /**
+   * The maximum number of items to show in the tag cloud. If there
+   * are more than this many items, only this many, with the highest
+   * value fields, will be shown. Defaults to 15.
+   */
+  maxValues: number;
+  /**
+   * A function that will get called with the selected SentimentTagCloudValue
+   * object if one is clicked.
+   */
+  callback: (tcv: SentimentTagCloudValue) => void;
+};
+
+type SentimentTagCloudDefaultProps = {
+  maxValues: number;
+};
+
+/**
+ * Display a linear tag "cloud" where the items are proportionally sized
+ * based on an associated value.
+ */
+export default class SentimentTagCloud extends React.Component<SentimentTagCloudDefaultProps, SentimentTagCloudProps, void> {
+  static defaultProps = {
+    maxValues: 15,
+  };
+
+  static displayName = 'SentimentTagCloud';
+
+  static SentimentTagCloudValue;
+
+  static mapRange(num, sentiment) {
+    if (sentiment === 'positive') {
+      const inMin = 1;
+      const inMax = 8;
+      const outMin = 6;
+      const outMax = 10;
+      return (((num - inMin) * (outMax - outMin)) / (inMax - inMin)) + outMin;
+    } else if (sentiment === 'negative') {
+      const inMin = 1;
+      const inMax = 8;
+      const outMin = 1;
+      const outMax = 5;
+      return (((num - inMin) * (outMin - outMax)) / (inMax - inMin)) + outMax;
+    }
+    return null;
+  }
+
+  static getAdjustedValue(value: number, max: number, sentiment: string): number {
+    const ratio = value / max;
+    const timesSeven = ratio * 7;
+    const oneThroughEight = Math.round(timesSeven) + 1;
+    const mappedValue = this.mapRange(oneThroughEight, sentiment);
+    return Math.round(mappedValue);
+  }
+
+  render() {
+    let tagCloudValues = this.props.positiveTags.concat(this.props.negativeTags);
+    const maxValue = tagCloudValues.reduce((max, tcv) => {
+      return Math.max(tcv.value, max);
+    }, 0,
+    );
+
+    if (tagCloudValues.length > this.props.maxValues) {
+      // Sort numerically by value
+      tagCloudValues.sort((tcv1: SentimentTagCloudValue, tcv2: SentimentTagCloudValue) => {
+        if (tcv1.value === tcv2.value) {
+          return 0;
+        }
+        if (tcv1.value < tcv2.value) {
+          return 1;
+        }
+        return -1;
+      });
+      // Remove the items with the lowest values
+      tagCloudValues = tagCloudValues.slice(0, this.props.maxValues);
+    }
+
+    // Sort alphabetically by label
+    tagCloudValues.sort((tcv1: SentimentTagCloudValue, tcv2: SentimentTagCloudValue) => {
+      return tcv1.label.localeCompare(tcv2.label);
+    });
+
+    const cloudItems = tagCloudValues.map((tcv) => {
+      const size = SentimentTagCloud.getAdjustedValue(tcv.value, maxValue, tcv.sentiment);
+      const callback = (event: Event & { target: HTMLAnchorElement }) => {
+        this.props.callback(tcv);
+        event.target.blur();
+      };
+      return (
+        <li key={tcv.label}>
+          <a className={`attivio-sentiment-cloud-level-${size}`} onClick={callback} role="button" tabIndex={0}>
+            {tcv.label}
+          </a>
+        </li>
+      );
+    });
+
+    return (
+      <ul className="attivio-sentiment-cloud list-inline">
+        {cloudItems}
+      </ul>
+    );
+  }
+}
+
+SentimentTagCloud.SentimentTagCloudValue = SentimentTagCloudValue;

--- a/src/components/SentimentTagCloudFacetContents.js
+++ b/src/components/SentimentTagCloudFacetContents.js
@@ -1,0 +1,99 @@
+// @flow
+
+import React from 'react';
+
+import SearchFacetBucket from '../api/SearchFacetBucket';
+import SentimentTagCloud, { SentimentTagCloudValue } from './SentimentTagCloud';
+
+type SentimentTagCloudFacetContentsProps = {
+  /** The buckets for positive keyphrases. */
+  positiveBuckets: Array<SearchFacetBucket>;
+  /** The buckets for negative keyphrases. */
+  negativeBuckets: Array<SearchFacetBucket>;
+  /**
+   * The maximum number of items to show in a facet. If there
+   * are more than this many buckets for the facet, only this many, with
+   * the highest counts, will be shown. Defaults to 15.
+   */
+  maxBuckets: number;
+  /** Callback to add a filter for this facet. */
+  addFacetFilter: (bucket: SearchFacetBucket) => void;
+};
+
+/** Display the values for positive and negative keyphrases in a list with TagClouds. */
+export default class SentimentTagCloudFacetContents extends React.Component<void, SentimentTagCloudFacetContentsProps, void> {
+  static displayName = 'SentimentTagCloudFacetContents';
+
+  constructor(props: SentimentTagCloudFacetContentsProps) {
+    super(props);
+    (this: any).tagCloudCallback = this.tagCloudCallback.bind(this);
+  }
+
+  tagCloudCallback(tcv: SentimentTagCloudValue) {
+    const selectedBucket = {};
+    if (tcv.sentiment === 'positive') {
+      selectedBucket.value = this.props.positiveBuckets.find((bucket) => {
+        const bucketLabel = bucket.displayLabel();
+        return (bucketLabel === tcv.label);
+      });
+      selectedBucket.sentiment = 'positive';
+    } else if (tcv.sentiment === 'negative') {
+      selectedBucket.value = this.props.negativeBuckets.find((bucket) => {
+        const bucketLabel = bucket.displayLabel();
+        return (bucketLabel === tcv.label);
+      });
+      selectedBucket.sentiment = 'negative';
+    }
+
+    if (selectedBucket) {
+      this.props.addFacetFilter(selectedBucket);
+    }
+  }
+
+  // Check if keyphrase bucket is a part of keyphrase bucketList
+  // and if the count for bucket is greater than it's match in the bucketList,
+  // if so, return bucket with count updated as the difference in values of count of matching buckets;
+  // otherwise return null
+  handleDuplicateBucketInBucketList(bucket: SearchFacetBucket, bucketList: Array<SearchFacetBucket>) {
+    let i;
+    for (i = 0; i < bucketList.length; i++) {
+      if (bucketList[i].value === bucket.value) {
+        if (bucketList[i].count < bucket.count) {
+          bucket.count -= bucketList[i].count;
+          return bucket;
+        } else if (bucketList[i].count > bucket.count) {
+          return null;
+        } else if (bucketList[i].count === bucket.count) {
+          return bucket;
+        }
+      }
+    }
+    return bucket;
+  }
+
+  render() {
+    const positiveTagCloudValues = [];
+    this.props.positiveBuckets.forEach((bucket) => {
+      const record = this.handleDuplicateBucketInBucketList(bucket, this.props.negativeBuckets);
+      if (record) {
+        const bucketLabel = record.displayLabel();
+        positiveTagCloudValues.push(new SentimentTagCloudValue(bucketLabel, record.count, 'positive'));
+      }
+    });
+    const negativeTagCloudValues = [];
+    this.props.negativeBuckets.forEach((bucket) => {
+      const record = this.handleDuplicateBucketInBucketList(bucket, this.props.positiveBuckets);
+      if (record) {
+        const bucketLabel = record.displayLabel();
+        negativeTagCloudValues.push(new SentimentTagCloudValue(bucketLabel, record.count, 'negative'));
+      }
+    });
+
+    return <SentimentTagCloud
+      positiveTags={positiveTagCloudValues}
+      negativeTags={negativeTagCloudValues}
+      maxValues={this.props.maxBuckets}
+      callback={this.tagCloudCallback}
+    />;
+  }
+}


### PR DESCRIPTION
Creates a sentiment based tag cloud from search facets. The Facet component can now accept ‘sentimenttagcloud’ as the type and two search facets containing positive and negative key phrases as props that are named ‘positiveKeyphrases’ and ‘negativeKeyphrases’. 

SentimentTagCloudFacetContents handles the case when there are same values in positive and negative key phrases. For example, if there’s a key phrase x in positive key phrases with the count value as 10, and it also is encountered in negative key phrases with a count value of 5. Then the difference between these count values is calculated (10 – 5 = 5) and the key phrase is displayed as positive with the count value of 5.

SentimentTagCloud finally displays the key phrases by mapping their count values to an integer between 1 to 10, where the integers 1 to 5 are for negative sentiment (1 being the most negative and 5 being the least negative) and the integers 6 to 10 are for positive sentiment (6 being the least positive and 10 being the most positive). 

attivio-search-results.less contains the styling for the key phrases under the class name attivio-sentiment-cloud.

Here's an example sentiment tag cloud:
![image](https://user-images.githubusercontent.com/31805650/43488603-4704c9b0-94e8-11e8-98fa-cf90e4024d46.png)

