### PR TITLE
issue-31: Update styling of TagCloud component

### DIFF
--- a/docs/style/bootstrap/attivio-search-results.less
+++ b/docs/style/bootstrap/attivio-search-results.less
@@ -692,51 +692,58 @@
 	text-align: center;
 }
 .attivio-cloud li {
-	padding: .1em 0.25em;
+	margin: 0.125rem;
+	padding: 0.4375rem;
+	transition: all .2s ease-in-out;
+}
+.attivio-cloud li:hover,
+.attivio-cloud li:focus {
+    transform:scale(1.1);
 }
 .attivio-cloud li a:hover {
-	color: #3276b1;
+    color: #3276b1;
+    text-decoration: none;
 }
 .attivio-cloud-level-1,
 .attivio-facet li .attivio-cloud-level-1 {
 	color: #767676;
-	font-size: 9px;
+	font-size: 12px;
 }
 .attivio-cloud-level-2,
 .attivio-facet li .attivio-cloud-level-2 {
 	color: #6d6e70;
-	font-size: 10px;
+	font-size: 15px;
 }
 .attivio-cloud-level-3,
 .attivio-facet li .attivio-cloud-level-3 {
 	color: #58595b;
-	font-size: 11px;
+	font-size: 18px;
 }
 .attivio-cloud-level-4,
 .attivio-facet li .attivio-cloud-level-4 {
 	color: #404041;
-	font-size: 12px;
+	font-size: 22px;
 }
 .attivio-cloud-level-5,
 .attivio-facet li .attivio-cloud-level-5 {
 	color: #231f20;
-	font-size: 13px;
+	font-size: 26px;
 }
 .attivio-cloud-level-6,
 .attivio-facet li .attivio-cloud-level-6 {
 	color: #000;
-	font-size: 14px;
+	font-size: 30px;
 }
 .attivio-cloud-level-7,
 .attivio-facet li .attivio-cloud-level-7 {
 	color: #000;
-	font-size: 15px;
+	font-size: 35px;
 	font-weight: 700;
 }
 .attivio-cloud-level-8,
 .attivio-facet li .attivio-cloud-level-8 {
 	color: #000;
-	font-size: 16px;
+	font-size: 40px;
 	font-weight: 700;
 }
 


### PR DESCRIPTION
Updates the styling of tagCloud component in the attivio-search-results.less file. The difference in the occurrence of keywords is conveyed better with this styling, and if you hover over a key phrase it grows in size.
Here are some screenshots for comparison:
Old TagCloud:
![old-tag-cloud](https://user-images.githubusercontent.com/31805650/43609375-cff99324-9671-11e8-9749-420b102445df.PNG)
Selection in old TagCloud:
![old-tag-cloud-selected](https://user-images.githubusercontent.com/31805650/43609394-dc9ea38a-9671-11e8-96eb-319c9b563ccf.png)

Updated TagCloud:
![tag-cloud](https://user-images.githubusercontent.com/31805650/43609418-ee518156-9671-11e8-83ea-ec5910328c58.PNG)

Selection in updated TagCloud:
![tagcloud-selected](https://user-images.githubusercontent.com/31805650/43609431-fa5649d2-9671-11e8-943a-904c75bc8153.png)