### PR TITLE
issue-34: Use Color Map with fields for Pie Chart

### DIFF
--- a/src/components/Facet.js
+++ b/src/components/Facet.js
@@ -43,7 +43,7 @@ type FacetProps = {
   /** Controls the colors used to show various entity types (the value can be any valid CSS color) */
   entityColors: Map<string, string>;
   /** Controls the colors (specified in configurations) for specific fields used in pie charts */
-  fieldValueColors?: Map<string, Map<string, string>>;
+  fieldValueColors: Map<string, string>;
 }
 
 type FacetDefaultProps = {
@@ -52,7 +52,7 @@ type FacetDefaultProps = {
   collapse: boolean;
   bordered: boolean;
   entityColors: Map<string, string>;
-  fieldValueColors?: Map<string, Object>;
+  fieldValueColors: Map<string, Object>;
 };
 
 /**

--- a/src/components/PieChartFacetContents.js
+++ b/src/components/PieChartFacetContents.js
@@ -90,6 +90,14 @@ export default class PieChartFacetContents extends React.Component<PieChartFacet
 
   render() {
     const dataSet = this.props.buckets.map((bucket) => {
+      if (this.props.entityColors.has(bucket.value)) {
+        const sectorColor = this.props.entityColors.get(bucket.value);
+        return {
+          name: bucket.displayLabel(),
+          y: bucket.count,
+          color: sectorColor,
+        };
+      }
       return {
         name: bucket.displayLabel(),
         y: bucket.count,


### PR DESCRIPTION
Modifies Facet component to take in an optional prop fieldValueColors which can be specified in the configuration.properties.js file ([in SearchUI](https://github.com/attivio/searchui/blob/master/frontend/configuration.properties.js)). If a sector is selected, the pie chart will update to the color of that sector instead of using the first value in entityColors prop. Here's an example:
![color-map-fix](https://user-images.githubusercontent.com/31805650/43742227-1a1c7180-999f-11e8-906d-6bd1ee0631c4.gif)
Users can configure the colors used for any fields that are used for creating pie charts. Here's an example configuration placed in configuration.properties.js for the above pie chart which uses the field table:
```
fieldValueColors: {
		table: {
			'Employees': '#007dbc',
			'Email': '#ed7a23',
			'News': '#fedd0e',
			'Research': '#db2e75',
			'Grant Proposal': '#ef8baa',
			'Dissertation': '#fcb62c',
		},
		sentiment: {
			pos: 'lightgreen',
			neg: '#ff6666',
		},
	},
```