### PR TITLE
issue-43: MiniSearchUI can now be integrated with "external" results and components

### DIFF
--- a/src/components/MiniSearchUI.js
+++ b/src/components/MiniSearchUI.js
@@ -8,6 +8,7 @@ import SearchResults from '../components/SearchResults';
 import Scrollable from '../components/Scrollable';
 import SearchResultsCount from '../components/SearchResultsCount';
 import ObjectUtils from '../util/ObjectUtils';
+import QueryResponse from '../api/QueryResponse';
 
 type MiniSearchUIProps = {
   /**
@@ -15,11 +16,19 @@ type MiniSearchUIProps = {
    * the MiniSearchUI. Optional—defaults to 100%.
    */
   scale: number;
+  onSearch?: (q: string) => void;
+  updateQuery?: (q: string) => void;
+  response?: QueryResponse;
+  error?: string | null;
 };
 
 type MiniSearchUIDefaultProps = {
   scale: number;
 };
+
+type MiniSearchUIState = {
+  query: string;
+}
 
 /**
  * A miniature, self-contained component that presentds super simple search UI including a text field for the
@@ -27,7 +36,7 @@ type MiniSearchUIDefaultProps = {
  * showing the resulting documents. It must be nested inside a Searcher component and will use that parent
  * Searcher to manage its state.
  */
-export default class MiniSearchUI extends React.Component<MiniSearchUIDefaultProps, MiniSearchUIProps, void> {
+export default class MiniSearchUI extends React.Component<MiniSearchUIDefaultProps, MiniSearchUIProps, MiniSearchUIState> {
   static defaultProps = {
     scale: 1.0,
   };
@@ -40,18 +49,30 @@ export default class MiniSearchUI extends React.Component<MiniSearchUIDefaultPro
 
   constructor(props: MiniSearchUIProps) {
     super(props);
+    this.state = {
+      query: '*',
+    };
     (this: any).doSearch = this.doSearch.bind(this);
     (this: any).updateSearchQuery = this.updateSearchQuery.bind(this);
   }
 
   doSearch() {
-    const searcher = this.context.searcher;
-    searcher.doSearch();
+    if (this.props.onSearch) {
+      this.props.onSearch(this.state.query);
+    } else {
+      const searcher = this.context.searcher;
+      searcher.doSearch();
+    }
   }
 
   updateSearchQuery(query: string) {
-    const searcher = this.context.searcher;
-    searcher.updateQuery(query);
+    if (this.props.updateQuery) {
+      this.props.updateQuery(query);
+    } else {
+      const searcher = this.context.searcher;
+      searcher.updateQuery(query);
+    }
+    this.setState({ query });
   }
 
   render() {
@@ -60,12 +81,16 @@ export default class MiniSearchUI extends React.Component<MiniSearchUIDefaultPro
         <NavbarSearch
           onSearch={this.doSearch}
           updateSearchString={this.updateSearchQuery}
-          value={this.context.searcher.state.query}
+          value={this.state.query}
           style={{
             marginLeft: '8px',
           }}
         />
-        <SearchResultsCount style={{ marginLeft: '20px', paddingBottom: '8px' }} />
+        <SearchResultsCount
+          style={{ marginLeft: '20px', paddingBottom: '8px' }}
+          response={this.props.response}
+          error={this.props.error}
+        />
         <Scrollable
           style={{
             height: '428px',
@@ -81,6 +106,7 @@ export default class MiniSearchUI extends React.Component<MiniSearchUIDefaultPro
             style={{
               transform: `scale(${this.props.scale}, ${this.props.scale})`,
             }}
+            response={this.props.response}
           />
         </Scrollable>
       </div>

--- a/src/components/SearchResults.js
+++ b/src/components/SearchResults.js
@@ -31,6 +31,13 @@ type SearchResultsProps = {
   showRatings: boolean;
   /** A style to apply to the results list */
   style: ?any;
+  /**
+   * A response can be passed in from custom searches if you don't want
+   *  to use the response on the searcher in this.context
+   */
+  response?: QueryResponse | null;
+  /** Offset of search results for long scrolling or pagination */
+  offset: number;
 };
 
 type SearchResultsDefaultProps = {
@@ -40,6 +47,8 @@ type SearchResultsDefaultProps = {
   entityFields: Map<string, string>;
   showTags: boolean;
   showRatings: boolean;
+  response: QueryResponse | null;
+  offset: number;
 };
 
 /**
@@ -54,6 +63,8 @@ export default class SearchResults extends React.Component<SearchResultsDefaultP
     entityFields: new Map([['people', 'People'], ['locations', 'Locations'], ['companies', 'Companies']]),
     showTags: true,
     showRatings: true,
+    response: null,
+    offset: 0,
   };
 
   static contextTypes = {
@@ -64,8 +75,8 @@ export default class SearchResults extends React.Component<SearchResultsDefaultP
 
   renderResults() {
     const searcher = this.context.searcher;
-    const response = searcher.state.response;
-    const offset = searcher.state.resultsOffset;
+    const response = this.props.response !== null ? this.props.response : searcher.state.response;
+    const offset = this.props.response ? this.props.offset : searcher.state.resultsOffset;
     if (response && response.documents && response.documents.length > 0) {
       const documents = response.documents;
       const results = [];

--- a/src/components/SearchResultsCount.js
+++ b/src/components/SearchResultsCount.js
@@ -2,11 +2,35 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+type SearchResultsCountProps = {
+  /**
+   * A response can be passed in from custom searches if you don't want
+   *  to use the response on the searcher in this.context
+   */
+  response?: QueryResponse | null;
+  /**
+   * If attempting to pass in a custom response, there may be queries that result in errors,
+   * which can be passed in here. Otherwise the error from the searcher
+   * on this.context will be used.
+   */
+  error?: string | null;
+}
+
+type SearchResultsCountDefaultProps = {
+  response: QueryResponse | null;
+  error?: string | null;
+}
+
 /**
  * The count of search results or an indication
  * that a search hasn't yet happened.
  */
-export default class SearchResultsCount extends React.Component<void, {}, void> {
+export default class SearchResultsCount extends React.Component<SearchResultsCountProps, SearchResultsCountDefaultProps, void> {
+  static defaultProps = {
+    response: null,
+    error: null,
+  }
+
   static contextTypes = {
     searcher: PropTypes.any,
   };
@@ -14,38 +38,43 @@ export default class SearchResultsCount extends React.Component<void, {}, void> 
   static displayName = 'SearchResultsCount';
 
   render() {
-    const searcher = this.context.searcher;
+    let response;
     let message;
     let countMessage;
-    if (searcher) {
-      const response = searcher.state.response;
-      if (response) {
-        const count = response.totalHits;
-        if (count === 0) {
-          countMessage = 'No results found';
-        } else if (count === 1) {
-          countMessage = '1 result found';
-        } else {
-          const countStr = Number(count).toLocaleString();
-          countMessage = `${countStr} results found`;
-        }
-        message = (
-          <span>
-            {countMessage}
-            <span style={{ fontWeight: 'normal' }}>
-              {' '}
-              (in {response.totalTime}ms)
-            </span>
-          </span>
-        );
-      } else if (searcher.state.error) {
-        // got an error...
-        message = `Error: ${searcher.state.error}`;
-      } else {
-        message = ''; // Not yet searched...
-      }
+    if (this.props.response) {
+      response = this.props.response;
     } else {
-      message = 'No searcher is configured.';
+      const searcher = this.context.searcher;
+      if (searcher) {
+        response = searcher.state.response;
+      }
+    }
+    if (response) {
+      const count = response.totalHits;
+      if (count === 0) {
+        countMessage = 'No results found';
+      } else if (count === 1) {
+        countMessage = '1 result found';
+      } else {
+        const countStr = Number(count).toLocaleString();
+        countMessage = `${countStr} results found`;
+      }
+      message = (
+        <span>
+          {countMessage}
+          <span style={{ fontWeight: 'normal' }}>
+            {' '}
+            (in {response.totalTime}ms)
+          </span>
+        </span>
+      );
+    } else if (this.props.error) {
+      message = `Error: ${this.props.error}`;
+    } else if (this.context.searcher.state.error) {
+        // got an error...
+      message = `Error: ${this.context.searcher.state.error}`;
+    } else {
+      message = ''; // Not yet searched...
     }
 
     return (


### PR DESCRIPTION
MiniSearchUI can now take optional props for results to render. These props, in one way or another, are propagated on to SearchResultsCount and SearchResults, and so these components were also updated as part of this new feature. 

MiniSearchUI also takes props for  functions to call when the user enters a query and/or clicks search, so that the results being passed in can be updated accordingly. 