### PR TITLE
Bug/plat 42805

### DIFF
--- a/src/components/Masthead.js
+++ b/src/components/Masthead.js
@@ -129,7 +129,7 @@ class Masthead extends React.Component<MastheadDefaultProps, MastheadProps, Mast
     }
   }
 
-  navigateHome() {
+  navigateHome = () => {
     if (this.homeLink) {
       this.homeLink.blur();
     }

--- a/src/components/Masthead.js
+++ b/src/components/Masthead.js
@@ -18,7 +18,8 @@ type MastheadProps = {
   logoAlt: string | null;
   /** The route to navigate to when the user clicks the logo. Defaults to '/' */
   homeRoute: string | null;
-  /** The optional url to navigate to when the user clicks the logo. If homeRoute
+  /**
+   * The optional url to navigate to when the user clicks the logo. If homeRoute
    *  and homeUrl are both specified, homeUrl takes precedence.
    */
   homeUrl: string | null;
@@ -52,7 +53,7 @@ type MastheadDefaultProps = {
   logoUri: string | null;
   logoAlt: string | null;
   homeRoute: string | null;
-  homeUrl: ?string;
+  homeUrl: string | null;
   applicationName: string | null;
   multiline: boolean;
   searchEngineType: 'attivio' | 'solr' | 'elastic';

--- a/src/components/Masthead.js
+++ b/src/components/Masthead.js
@@ -48,6 +48,7 @@ type MastheadDefaultProps = {
   logoUri: string | null;
   logoAlt: string | null;
   homeRoute: string | null;
+  homeUrl: ?string;
   applicationName: string | null;
   multiline: boolean;
   searchEngineType: 'attivio' | 'solr' | 'elastic';
@@ -72,6 +73,7 @@ class Masthead extends React.Component<MastheadDefaultProps, MastheadProps, Mast
     logoUri: 'img/attivio-logo-reverse.png',
     logoAlt: 'Attivio Home',
     homeRoute: '/',
+    homeUrl: null,
     logoutFunction: null,
     applicationName: 'Cognitive Search',
     multiline: false,
@@ -97,12 +99,14 @@ class Masthead extends React.Component<MastheadDefaultProps, MastheadProps, Mast
 
   state: MastheadState;
 
-  componentWillMount() {
+  componentDidMount() {
     this.updateUser();
   }
 
-  componentWillReceiveProps() {
-    this.updateUser();
+  componentWillReceiveProps(nextProps) {
+    if (this.props.username !== nextProps.username) {
+      this.updateUser();
+    }
   }
 
   updateUser() {
@@ -129,17 +133,22 @@ class Masthead extends React.Component<MastheadDefaultProps, MastheadProps, Mast
     }
   }
 
-  navigateHome = () => {
+  navigateHome() {
     if (this.homeLink) {
       this.homeLink.blur();
     }
-    this.context.searcher.reset();
-    this.props.history.push({ pathname: this.props.homeRoute, search: this.props.location.search });
+    if (this.context && this.context.searcher) {
+      this.context.searcher.reset();
+    }
+    this.props.history.push({
+      pathname: this.props.homeRoute,
+      search: this.props.location.search,
+    });
   }
 
   homeLink: ?HTMLAnchorElement;
 
-  render() {
+  renderButton() {
     let engineInfo = null;
     if (this.props.searchEngineType === 'solr') {
       engineInfo = (
@@ -177,6 +186,48 @@ class Masthead extends React.Component<MastheadDefaultProps, MastheadProps, Mast
       );
     }
 
+    const logo = (
+      <img
+        src={this.props.logoUri}
+        alt={this.props.logoAlt}
+        className="attivio-globalmast-logo-img"
+      />
+    );
+
+    if (this.props.homeUrl) {
+      return (
+        <a
+          style={{
+            backgroundColor: 'transparent',
+            borderWidth: 0,
+            textDecoration: 'none',
+          }}
+          role="button"
+          href={this.props.homeUrl}
+          className="attivio-globalmast-logo attivio-globalmast-separator after"
+        >
+          {logo}
+          {engineInfo}
+        </a>
+      );
+    }
+
+    return (
+      <button
+        style={{ backgroundColor: 'transparent', borderWidth: 0 }}
+        onClick={this.navigateHome}
+        className="attivio-globalmast-logo attivio-globalmast-separator after"
+        ref={(c) => {
+          this.homeLink = c;
+        }}
+      >
+        {logo}
+        {engineInfo}
+      </button>
+    );
+  }
+
+  render() {
     let logoutFunction = this.props.logoutFunction;
     if (this.state.userInfo) {
       if (this.state.userInfo.saml) {
@@ -191,18 +242,7 @@ class Masthead extends React.Component<MastheadDefaultProps, MastheadProps, Mast
     return (
       <header className="attivio-globalmast attivio-minwidth">
         <div className="attivio-container">
-          <button
-            style={{ backgroundColor: 'transparent', borderWidth: 0 }}
-            onClick={this.navigateHome}
-            className="attivio-globalmast-logo attivio-globalmast-separator after"
-
-            ref={(c) => {
-              this.homeLink = c;
-            }}
-          >
-            <img src={this.props.logoUri} alt={this.props.logoAlt} className="attivio-globalmast-logo-img" />
-            {engineInfo}
-          </button>
+          {this.renderButton()}
           <div className={`attivio-globalmast-appname attivio-globalmast-separator after ${this.props.multiline ? '' : 'nowrap'}`}>
             {this.props.applicationName}
           </div>

--- a/src/components/Masthead.js
+++ b/src/components/Masthead.js
@@ -18,6 +18,10 @@ type MastheadProps = {
   logoAlt: string | null;
   /** The route to navigate to when the user clicks the logo. Defaults to '/' */
   homeRoute: string | null;
+  /** The optional url to navigate to when the user clicks the logo. If homeRoute
+   *  and homeUrl are both specified, homeUrl takes precedence.
+   */
+  homeUrl: string | null;
   /** The name of the application. */
   applicationName: string | null;
   /** If set, then the application name will wrap to two lines. */


### PR DESCRIPTION
Addresses [PLAT-42805](https://jira.attivio.com/browse/PLAT-42805).

Adds an additional optional prop `homeUrl` to `<Masthead />`.
If the prop is specified, the logo becomes an `<a />` instead of a `<button />`.
If not specified, the `homeRoute` is used.
If neither are specified, the default `/` for `homeRoute` is used.
If both are specified `homeUrl` takes precedence.

Modified `componentWillReceiveProps` to only update the user when the username prop changes. This reduces unnecessary renders by about 10x.

Changed `componentWillMount` to `componentDidMount`. `componentWillMount` is deprecated and should never have been used to fetch data from the server or set state. `componentDidMount` will serve the same purpose in a safer way. This could use more attention, but is beyond the scope of this PR.
See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html for more information on recommended practices for async rendering.