### PR TITLE
Feat/plat 42929

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -286,6 +286,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
       "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "extend": "~3.0.0",
         "semver": "~5.0.1"
@@ -295,7 +296,8 @@
           "version": "5.0.3",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
           "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -2655,7 +2657,8 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-0.0.2.tgz",
       "integrity": "sha1-JrOIXRD6E9t/wBquOquHAZngEkw=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "buffer-shims": {
       "version": "1.0.0",
@@ -7440,7 +7443,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7461,12 +7465,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7481,17 +7487,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7608,7 +7617,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7620,6 +7630,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7634,6 +7645,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7641,12 +7653,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -7665,6 +7679,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7745,7 +7760,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7757,6 +7773,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7842,7 +7859,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7878,6 +7896,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7897,6 +7916,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7940,12 +7960,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -8960,6 +8982,7 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-1.0.0.tgz",
       "integrity": "sha1-zBzjjkU7+YSg93AtLdWcc9CBKEo=",
       "dev": true,
+      "optional": true,
       "requires": {
         "agent-base": "2",
         "debug": "2",
@@ -8971,6 +8994,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -9022,6 +9046,7 @@
       "resolved": "https://registry.npmjs.org/httpntlm/-/httpntlm-1.6.1.tgz",
       "integrity": "sha1-rQFScUOi6Hc8+uapb1hla7UqNLI=",
       "dev": true,
+      "optional": true,
       "requires": {
         "httpreq": ">=0.4.22",
         "underscore": "~1.7.0"
@@ -9031,7 +9056,8 @@
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
           "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -9039,7 +9065,8 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.4.24.tgz",
       "integrity": "sha1-QzX/2CzZaWaKOUZckprGHWOTYn8=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "https-browserify": {
       "version": "1.0.0",
@@ -9052,6 +9079,7 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
       "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
       "dev": true,
+      "optional": true,
       "requires": {
         "agent-base": "2",
         "debug": "2",
@@ -9063,6 +9091,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -10885,13 +10914,15 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-0.1.0.tgz",
       "integrity": "sha1-YjUag5VjrF/1vSbxL2Dpgwu3UeY=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "libmime": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/libmime/-/libmime-3.0.0.tgz",
       "integrity": "sha1-UaGp50SOy9Ms2lRCFnW7IbwJPaY=",
       "dev": true,
+      "optional": true,
       "requires": {
         "iconv-lite": "0.4.15",
         "libbase64": "0.1.0",
@@ -10902,7 +10933,8 @@
           "version": "0.4.15",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
           "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -10910,7 +10942,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/libqp/-/libqp-1.1.0.tgz",
       "integrity": "sha1-9ebgatdLeU+1tbZpiL9yjvHe2+g=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "listify": {
       "version": "1.0.0",
@@ -10972,9 +11005,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -11234,6 +11267,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -11311,7 +11345,8 @@
           "version": "2.16.3",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
           "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "http-signature": {
           "version": "1.1.1",
@@ -12427,13 +12462,15 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/nodemailer-fetch/-/nodemailer-fetch-1.6.0.tgz",
       "integrity": "sha1-ecSQihwPXzdbc/6IjamCj23JY6Q=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "nodemailer-shared": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/nodemailer-shared/-/nodemailer-shared-1.1.0.tgz",
       "integrity": "sha1-z1mU4v0mjQD1zw+nZ6CBae2wfsA=",
       "dev": true,
+      "optional": true,
       "requires": {
         "nodemailer-fetch": "1.6.0"
       }
@@ -12466,7 +12503,8 @@
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/nodemailer-wellknown/-/nodemailer-wellknown-0.1.10.tgz",
       "integrity": "sha1-WG24EB2zDLRDjrVGc3pBqtDPE9U=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "nodemon": {
       "version": "1.15.1",
@@ -20413,13 +20451,15 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
       "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "smtp-connection": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-2.12.0.tgz",
       "integrity": "sha1-1275EnyyPCJZ7bHoNJwujV4tdME=",
       "dev": true,
+      "optional": true,
       "requires": {
         "httpntlm": "1.6.1",
         "nodemailer-shared": "1.1.0"
@@ -20772,6 +20812,7 @@
       "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
       "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
       "dev": true,
+      "optional": true,
       "requires": {
         "ip": "^1.1.4",
         "smart-buffer": "^1.0.13"
@@ -20782,6 +20823,7 @@
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-2.1.1.tgz",
       "integrity": "sha512-sFtmYqdUK5dAMh85H0LEVFUCO7OhJJe1/z2x/Z6mxp3s7/QPf1RkZmpZy+BpuU0bEjcV9npqKjq9Y3kwFUjnxw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "agent-base": "2",
         "extend": "3",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "extract-text-webpack-plugin": "3.0.0",
     "glamor": "2.20.40",
     "hygen": "1.5.8",
+    "lodash": "^4.17.11",
     "mapbox-gl": "0.40.1",
     "moment": "2.20.1",
     "prop-types": "15.6.0",

--- a/src/components/AuthRoute.js
+++ b/src/components/AuthRoute.js
@@ -67,7 +67,7 @@ class AuthRoute extends React.Component<AuthRouteDefaultProps, AuthRouteProps, A
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     AuthUtils.getLoggedInUserInfo((userInfo: any) => {
       this.setState({
         user: userInfo,

--- a/src/components/Configurable.js
+++ b/src/components/Configurable.js
@@ -28,12 +28,9 @@ function Configurable(WrappedComponent: React.Component): React.Component {
       };
     }
 
+    // FIXME: Never set state in componentDidMount
     componentDidMount() {
       this.fillWithDefaults(this.props);
-    }
-
-    componentWillReceiveProps(nextProps: any) {
-      this.fillWithDefaults(nextProps);
     }
 
     fillWithDefaults(props: any) {
@@ -46,6 +43,7 @@ function Configurable(WrappedComponent: React.Component): React.Component {
           filled[property] = this.context.configuration.get(name, property, props[property]);
         });
       }
+      console.log('<Configurable /> fillWithDefaults() : ', WrappedComponent.displayName);
       this.setState({
         filled: true,
         props: filled,

--- a/src/components/Configurable.js
+++ b/src/components/Configurable.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import ObjectUtils from '../util/ObjectUtils';
 
 type ConfigurableState = {
   filled: boolean;
@@ -31,6 +32,12 @@ function Configurable(WrappedComponent: React.Component): React.Component {
     // FIXME: Never set state in componentDidMount
     componentDidMount() {
       this.fillWithDefaults(this.props);
+    }
+
+    componentWillReceiveProps(nextProps: any) {
+      if (!ObjectUtils.deepEquals(this.props, nextProps)) {
+        this.fillWithDefaults(nextProps);
+      }
     }
 
     fillWithDefaults(props: any) {

--- a/src/components/Configurable.js
+++ b/src/components/Configurable.js
@@ -43,7 +43,7 @@ function Configurable(WrappedComponent: React.Component): React.Component {
           filled[property] = this.context.configuration.get(name, property, props[property]);
         });
       }
-      console.log('<Configurable /> fillWithDefaults() : ', WrappedComponent.displayName);
+
       this.setState({
         filled: true,
         props: filled,

--- a/src/components/ConfirmationDialog.js
+++ b/src/components/ConfirmationDialog.js
@@ -74,8 +74,8 @@ export default class ConfirmationDialog extends React.Component<ConfirmationDial
 
   render() {
     const okButtonStyle = this.props.dangerous ? 'danger' : 'primary';
-    return this.props.show ? (
-      <Modal show>
+    return (
+      <Modal show={this.props.show} onHide={this.props.onCancel}>
         <Modal.Header>
           <Modal.Title>{this.props.title}</Modal.Title>
         </Modal.Header>
@@ -87,6 +87,6 @@ export default class ConfirmationDialog extends React.Component<ConfirmationDial
           <Button onClick={this.props.onConfirm} bsStyle={okButtonStyle}>{this.props.confirmButtonLabel}</Button>
         </Modal.Footer>
       </Modal>
-    ) : null;
+    );
   }
 }

--- a/src/components/Details.js
+++ b/src/components/Details.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 
-type DetailsProps = {
+export type DetailsProps = {
   /**
    * The object to display in the details. May be null, in which case there is no selection
    * to display.

--- a/src/components/DropdownButton.js
+++ b/src/components/DropdownButton.js
@@ -6,6 +6,8 @@ import Dropdown from 'react-bootstrap/lib/Dropdown';
 import Toggle from './Toggle';
 
 type DropdownButtonProps = {
+  /** An optional custom className for the dropdown button */
+  buttonClassName: ?string;
   /** The DOM element's id property */
   id: string;
   /** The title to display on the un-opened dropdown button */
@@ -18,6 +20,8 @@ type DropdownButtonProps = {
   onOpen: (e: Event) => void;
   /** The callback to run when a menu item is selected */
   onSelect: (value: any, e: Event) => void;
+  /** An optional custom className for the dropdown options */
+  optionsClassName: ?string;
 };
 
 /**
@@ -27,13 +31,18 @@ export default class DropdownButton extends React.Component<void, DropdownButton
   static displayName = 'DropdownButton';
 
   render() {
-    const { titleClassName = '' } = this.props;
+    const { titleClassName = '', buttonClassName = '', optionsClassName = '' } = this.props;
+
     return (
-      <Dropdown id={this.props.id} className="attivio-dropdown" style={{ verticalAlign: 'unset' }}>
+      <Dropdown
+        id={this.props.id}
+        className={buttonClassName || 'attivio-dropdown'}
+        style={{ verticalAlign: 'unset' }}
+      >
         <Toggle bsRole="toggle" onClick={this.props.onOpen} customClassName={titleClassName}>
           {this.props.title}
         </Toggle>
-        <Dropdown.Menu bsRole="menu" onSelect={this.props.onSelect}>
+        <Dropdown.Menu bsRole="menu" onSelect={this.props.onSelect} className={optionsClassName}>
           {this.props.children}
         </Dropdown.Menu>
       </Dropdown>

--- a/src/components/DropdownButton.js
+++ b/src/components/DropdownButton.js
@@ -12,6 +12,8 @@ type DropdownButtonProps = {
   title: string;
   /** The menu items to display when the dropdown is opened */
   children: Children;
+  /** An optional custom className for the button title */
+  titleClassName: ?string;
   /** The callback to run when the dropdown is opened */
   onOpen: (e: Event) => void;
   /** The callback to run when a menu item is selected */
@@ -25,9 +27,10 @@ export default class DropdownButton extends React.Component<void, DropdownButton
   static displayName = 'DropdownButton';
 
   render() {
+    const { titleClassName = '' } = this.props;
     return (
       <Dropdown id={this.props.id} className="attivio-dropdown" style={{ verticalAlign: 'unset' }}>
-        <Toggle bsRole="toggle" onClick={this.props.onOpen}>
+        <Toggle bsRole="toggle" onClick={this.props.onOpen} customClassName={titleClassName}>
           {this.props.title}
         </Toggle>
         <Dropdown.Menu bsRole="menu" onSelect={this.props.onSelect}>

--- a/src/components/MasterDetails.js
+++ b/src/components/MasterDetails.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import Grid from 'react-bootstrap/lib/Grid';
 import Row from 'react-bootstrap/lib/Row';
@@ -68,13 +68,13 @@ type MasterDetailsProps = {
    * user filter the list of items in the table. May also be a function that uses selectedRows and
    * renders a header component. Optional; if not set, the table will be flush with the top of the details component.
    */
-  header: any;
+  header?: null | React.Node | (selectedRows: Array<string>) => React.Node;
   /**
    * A footer component that can be inserted below the table (but to the left of the
    * details component). For example, this might be used to include controls to paginate
    * the table. Optional.
    */
-  footer: any;
+  footer?: null | React.Node | (selectedRows: Array<string>) => React.Node;
   /**
    * This determines the ratio of table to details, based on Bootstrap's 12-column grid.
    * This is the width of the table; the details component will use the remainder. Optional;
@@ -104,33 +104,34 @@ type MasterDetailsProps = {
    * The class name to apply to the table element. Optional.
    */
   tableClassName: string;
-  /** Optional background color to apply to the last selected row. Only used if multiSelect is specified as well. Takes precedence
-   *  over all other background colors specified through classNames.
+  /**
+   * Optional background color to apply to the last selected row. Only used if multiSelect is specified as well.
+   * Takes precedence over all other background colors specified through classNames.
    */
   anchorRowBackgroundColor: ?string;
 };
 
 type MasterDetailsDefaultProps = {
   detailsProps: any;
+  footer?: null | React.Node | (selectedRows: Array<string>) => React.Node;
+  header?: null | React.Node | (selectedRows: Array<string>) => React.Node;
   multiSelect: boolean;
-  onSelect: null | (rowsIds: Array<string>, newlySelectedRowId: string | null) => void;
-  sortColumn: number;
-  onSort: null | (sortColumn: number) => void;
-  header: any;
-  footer: any;
-  split: ColumnCount;
-  padding: number;
   noEmptySelection: boolean;
-  tableContainerClassName: string | void;
+  onSelect: null | (rowsIds: Array<string>, newlySelectedRowId: string | null) => void;
+  onSort: null | (sortColumn: number) => void;
+  padding: number;
   selectedClassName: string;
+  sortColumn: number;
+  split: ColumnCount;
   tableClassName: string;
+  tableContainerClassName: string | void;
 };
 
 type MasterDetailsState = {
-  /** The IDs of the selected rows */
-  selectedRows: Array<string>;
   /** The id for the most-recently selected row, to be displayed in the details pane. */
   detailsRowId: string;
+  /** The IDs of the selected rows */
+  selectedRows: Array<string>;
 };
 
 /**
@@ -141,18 +142,18 @@ type MasterDetailsState = {
 export default class MasterDetails extends React.Component<MasterDetailsDefaultProps, MasterDetailsProps, MasterDetailsState> {
   static defaultProps = {
     detailsProps: {},
-    multiSelect: false,
-    onSelect: null,
-    sortColumn: 0,
-    onSort: null,
-    header: null,
     footer: null,
-    split: 8,
-    padding: 0,
+    header: null,
+    multiSelect: false,
     noEmptySelection: false,
-    tableContainerClassName: undefined,
+    onSelect: null,
+    onSort: null,
+    padding: 0,
     selectedClassName: 'attivio-table-row-selected',
+    sortColumn: 0,
+    split: 8,
     tableClassName: 'table table-striped attivio-table attivio-table-sm',
+    tableContainerClassName: undefined,
   };
 
   static displayName = 'MasterDetails';
@@ -174,7 +175,7 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
       if (newProps.rows.length === 0) {
         this.setState({
           selectedRows: [],
-          detailsRowId: null,
+          detailsRowId: '',
         });
       } else {
         const ids = newProps.rows.map((row) => {
@@ -200,7 +201,7 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
   selectionChanged(selectedRowIds: Array<string>, newlySelectedRowId: string | null) {
     this.setState({
       selectedRows: selectedRowIds,
-      detailsRowId: newlySelectedRowId || null,
+      detailsRowId: newlySelectedRowId || '',
     }, () => {
       if (this.props.onSelect) {
         this.props.onSelect(selectedRowIds, newlySelectedRowId);
@@ -217,12 +218,20 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
     return header;
   }
 
+  renderFooter() {
+    const { footer } = this.props;
+    const { selectedRows } = this.state;
+    if (typeof footer === 'function') {
+      return footer(selectedRows);
+    }
+    return footer;
+  }
+
   render() {
     const {
       columns,
       details: Detail,
       detailsProps,
-      footer,
       anchorRowBackgroundColor,
       multiSelect,
       noEmptySelection,
@@ -264,10 +273,10 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
                 noEmptySelection={noEmptySelection}
                 selectedClassName={selectedClassName}
                 tableClassName={tableClassName}
-                detailsRowId={this.state.detailsRowId}
+                activeRowId={this.state.detailsRowId}
                 anchorRowBackgroundColor={anchorRowBackgroundColor}
               />
-              {footer}
+              {this.renderFooter()}
             </div>
           </Col>
           <Col lg={detailsWidth} md={detailsWidth} sm={12} xs={12} style={{ paddingLeft: halfPadding, paddingRight: 0 }}>

--- a/src/components/MasterDetails.js
+++ b/src/components/MasterDetails.js
@@ -5,7 +5,6 @@ import * as React from 'react';
 import Grid from 'react-bootstrap/lib/Grid';
 import Row from 'react-bootstrap/lib/Row';
 import Col from 'react-bootstrap/lib/Col';
-
 import Table from './Table';
 
 type ColumnCount = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
@@ -32,7 +31,7 @@ type MasterDetailsProps = {
    * Custom properties to pass to the details component in addition to the "data" property.
    * Optional.
    */
-  detailsProps?: any;
+  detailsProps?: {};
   /**
    * If set, multiple rows in the table can be selected simultaneouysly. In this case, the
    * most recently selected row is shown in the details view.
@@ -61,7 +60,7 @@ type MasterDetailsProps = {
    * May be a component or a render function. If a function is passed it will be provided with the selected rows.
    * It can be inserted above the table (but to the left of the
    * details component). For example, this might be used to include controls that help the
-   * user filter the list of items in the table. Optional; if not set, the table will be flush with the 
+   * user filter the list of items in the table. Optional; if not set, the table will be flush with the
    * top of the details component.
    */
   header?: React.Node | (selectedRows: Array<{}>) => React.Node;
@@ -109,12 +108,12 @@ type MasterDetailsProps = {
 };
 
 type MasterDetailsDefaultProps = {
-  detailsProps: any;
+  detailsProps?: {};
   footer?: React.Node | (selectedRows: Array<{}>) => React.Node;
   header?: React.Node | (selectedRows: Array<{}>) => React.Node;
   multiSelect?: boolean;
   noEmptySelection?: boolean;
-  onSelect?: (selectedRows: Array<{}>, newlySelectedRows: {} | null) => void;
+  onSelect?: (selectedRows: Array<{}>, newlySelectedRow: {} | null) => void;
   onSort?: (sortColumn: number) => void;
   padding?: number;
   selectedClassName?: string;
@@ -137,7 +136,7 @@ type MasterDetailsState = {
  * simultaneously, then the details pane shows information aobut the most recently selected row.
  */
 export default class MasterDetails extends React.Component<MasterDetailsDefaultProps, MasterDetailsProps, MasterDetailsState> {
-  static defaultProps = {
+  static defaultProps: MasterDetailsDefaultProps = {
     detailsProps: {},
     footer: null,
     header: null,
@@ -207,7 +206,7 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
       multiSelect,
       noEmptySelection,
       onSort,
-      padding,
+      padding = 0,
       rows,
       selectedClassName,
       sortColumn,
@@ -236,7 +235,6 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
                 noEmptySelection={noEmptySelection}
                 selectedClassName={selectedClassName}
                 tableClassName={tableClassName}
-                activeRowIndex={detailsRow}
                 anchorRowBackgroundColor={anchorRowBackgroundColor}
               />
               {this.renderFooter()}

--- a/src/components/MasterDetails.js
+++ b/src/components/MasterDetails.js
@@ -104,6 +104,10 @@ type MasterDetailsProps = {
    * Takes precedence over all other background colors specified through classNames.
    */
   activeRowBackgroundColor?: string;
+  /**
+   * Row comparator function passed through to the Table component. See Table component for details.
+   */
+  rowComparator: (rowA: {}, rowB: {}) => boolean;
 };
 
 type MasterDetailsDefaultProps = {
@@ -202,6 +206,7 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
       noEmptySelection,
       onSort,
       padding = 0,
+      rowComparator,
       rows,
       selectedClassName,
       sortColumn,
@@ -231,6 +236,7 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
                 selectedClassName={selectedClassName}
                 tableClassName={tableClassName}
                 activeRowBackgroundColor={activeRowBackgroundColor}
+                rowComparator={rowComparator}
               />
               {this.renderFooter()}
             </div>

--- a/src/components/MasterDetails.js
+++ b/src/components/MasterDetails.js
@@ -39,10 +39,9 @@ type MasterDetailsProps = {
   multiSelect?: boolean;
   /**
    * This callback is called when the user changes the selection in the table. However the
-   * MasterDetails component and not its parent is responsible for maintaining the selection
-   * in the table; this callback is just a "courtesy" so the parent can do something such
-   * as change the enablement of buttons, etc., based on the selection. See the onSelect
-   * property of the Table component for more details.
+   * Table component is responsible for maintaining the selection in the table; this callback
+   * is just a "courtesy" so the parent can do something such as change the enablement of buttons,
+   * etc., based on the selection. See the onSelect property of the Table component for more details.
    */
   onSelect?: (selectedRows: Array<{}>, newlySelectedRow: {} | null) => void;
   /**
@@ -104,7 +103,7 @@ type MasterDetailsProps = {
    * Optional background color to apply to the last selected row. Only used if multiSelect is specified as well.
    * Takes precedence over all other background colors specified through classNames.
    */
-  anchorRowBackgroundColor?: string;
+  activeRowBackgroundColor?: string;
 };
 
 type MasterDetailsDefaultProps = {
@@ -199,7 +198,7 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
 
   render() {
     const {
-      anchorRowBackgroundColor,
+      activeRowBackgroundColor,
       columns,
       details: Detail,
       detailsProps,
@@ -235,7 +234,7 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
                 noEmptySelection={noEmptySelection}
                 selectedClassName={selectedClassName}
                 tableClassName={tableClassName}
-                anchorRowBackgroundColor={anchorRowBackgroundColor}
+                activeRowBackgroundColor={activeRowBackgroundColor}
               />
               {this.renderFooter()}
             </div>

--- a/src/components/MasterDetails.js
+++ b/src/components/MasterDetails.js
@@ -62,14 +62,14 @@ type MasterDetailsProps = {
    * user filter the list of items in the table. Optional; if not set, the table will be flush with the
    * top of the details component.
    */
-  header?: React.Node | (selectedRows: Array<{}>) => React.Node;
+  header?: null | React.Node | (selectedRows: Array<{}>) => React.Node;
   /**
    * May be a component or render function. If a function is passed it will be provided the selectedRows.
    * It can be inserted below the table (but to the left of the
    * details component). For example, this might be used to include controls to paginate
    * the table. Optional.
    */
-  footer?: React.Node | (selectedRows: Array<{}>) => React.Node;
+  footer?: null | React.Node | (selectedRows: Array<{}>) => React.Node;
   /**
    * This determines the ratio of table to details, based on Bootstrap's 12-column grid.
    * This is the width of the table; the details component will use the remainder. Optional;
@@ -107,19 +107,17 @@ type MasterDetailsProps = {
 };
 
 type MasterDetailsDefaultProps = {
-  detailsProps?: {};
-  footer?: React.Node | (selectedRows: Array<{}>) => React.Node;
-  header?: React.Node | (selectedRows: Array<{}>) => React.Node;
-  multiSelect?: boolean;
-  noEmptySelection?: boolean;
-  onSelect?: (selectedRows: Array<{}>, newlySelectedRow: {} | null) => void;
-  onSort?: (sortColumn: number) => void;
-  padding?: number;
-  selectedClassName?: string;
-  sortColumn?: number;
+  detailsProps: {};
+  footer: null | React.Node | (selectedRows: Array<{}>) => React.Node;
+  header: null | React.Node | (selectedRows: Array<{}>) => React.Node;
+  multiSelect: boolean;
+  noEmptySelection: boolean;
+  padding: number;
+  selectedClassName: string;
+  sortColumn: number;
   split: ColumnCount;
-  tableClassName?: string;
-  tableContainerClassName?: string;
+  tableClassName: string;
+  tableContainerClassName: string;
 };
 
 type MasterDetailsState = {
@@ -141,14 +139,12 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
     header: null,
     multiSelect: false,
     noEmptySelection: false,
-    onSelect: null,
-    onSort: null,
     padding: 0,
     selectedClassName: 'attivio-table-row-selected',
     sortColumn: 0,
     split: 8,
     tableClassName: 'table table-striped attivio-table attivio-table-sm',
-    tableContainerClassName: undefined,
+    tableContainerClassName: '',
   };
 
   static displayName = 'MasterDetails';

--- a/src/components/MasterDetails.js
+++ b/src/components/MasterDetails.js
@@ -187,7 +187,7 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
         const newDetailsRowId = (newSelectedRows.length > 0) ? (newSelectedRows[newSelectedRows.length - 1]) : '';
 
         this.setState({
-          selectedRows: newSelectedRows,
+          selectedRows: [newDetailsRowId],
           detailsRowId: newDetailsRowId,
         });
       }

--- a/src/components/MasterDetails.js
+++ b/src/components/MasterDetails.js
@@ -32,12 +32,12 @@ type MasterDetailsProps = {
    * Custom properties to pass to the details component in addition to the "data" property.
    * Optional.
    */
-  detailsProps: any;
+  detailsProps?: any;
   /**
    * If set, multiple rows in the table can be selected simultaneouysly. In this case, the
    * most recently selected row is shown in the details view.
    */
-  multiSelect: boolean;
+  multiSelect?: boolean;
   /**
    * This callback is called when the user changes the selection in the table. However the
    * MasterDetails component and not its parent is responsible for maintaining the selection
@@ -45,35 +45,33 @@ type MasterDetailsProps = {
    * as change the enablement of buttons, etc., based on the selection. See the onSelect
    * property of the Table component for more details.
    */
-  onSelect: null | (rowsIds: Array<string>, newlySelectedRowId: string | null) => void;
-  /**
-   * If set, the user can select multiple rows in the table.
-   */
-  multiSelect: boolean;
+  onSelect?: (selectedRows: Array<{}>, newlySelectedRow: {} | null) => void;
   /**
    * The column being sorted by, if any.
    * A callback used when the owner of the rows is doing any sorting. See the onSort property
    * in the Table component for more details.
    */
-  sortColumn: number;
+  sortColumn?: number;
   /**
    * A callback used when the owner of the rows is doing any sorting. See the onSort property
    * in the Table component for more details.
    */
-  onSort: null | (sortColumn: number) => void;
+  onSort?: (sortColumn: number) => void;
   /**
-   * A header component that can be inserted above the table (but to the left of the
+   * May be a component or a render function. If a function is passed it will be provided with the selected rows.
+   * It can be inserted above the table (but to the left of the
    * details component). For example, this might be used to include controls that help the
-   * user filter the list of items in the table. May also be a function that uses selectedRows and
-   * renders a header component. Optional; if not set, the table will be flush with the top of the details component.
+   * user filter the list of items in the table. Optional; if not set, the table will be flush with the 
+   * top of the details component.
    */
-  header?: null | React.Node | (selectedRows: Array<string>) => React.Node;
+  header?: React.Node | (selectedRows: Array<{}>) => React.Node;
   /**
-   * A footer component that can be inserted below the table (but to the left of the
+   * May be a component or render function. If a function is passed it will be provided the selectedRows.
+   * It can be inserted below the table (but to the left of the
    * details component). For example, this might be used to include controls to paginate
    * the table. Optional.
    */
-  footer?: null | React.Node | (selectedRows: Array<string>) => React.Node;
+  footer?: React.Node | (selectedRows: Array<{}>) => React.Node;
   /**
    * This determines the ratio of table to details, based on Bootstrap's 12-column grid.
    * This is the width of the table; the details component will use the remainder. Optional;
@@ -86,51 +84,51 @@ type MasterDetailsProps = {
    * The number of pixels of padding to include between the table and the details component.
    * Optional; defaults to 0 pixels.
    */
-  padding: number;
+  padding?: number;
   /**
-   * See the noEmptySelection property of the Table component for details
+   * See the noEmptySelection property of the Table component for details. Defaults to false.
    */
-  noEmptySelection: boolean;
+  noEmptySelection?: boolean;
   /**
    * The class name to apply to the parent div element containing the table. Optional
    */
-  tableContainerClassName: string | void;
+  tableContainerClassName?: string;
   /**
    * The class name to apply only to tr elements of selected rows in the table. Optional
    */
-  selectedClassName: string;
+  selectedClassName?: string;
   /**
    * The class name to apply to the table element. Optional.
    */
-  tableClassName: string;
+  tableClassName?: string;
   /**
    * Optional background color to apply to the last selected row. Only used if multiSelect is specified as well.
    * Takes precedence over all other background colors specified through classNames.
    */
-  anchorRowBackgroundColor: ?string;
+  anchorRowBackgroundColor?: string;
 };
 
 type MasterDetailsDefaultProps = {
   detailsProps: any;
-  footer?: null | React.Node | (selectedRows: Array<string>) => React.Node;
-  header?: null | React.Node | (selectedRows: Array<string>) => React.Node;
-  multiSelect: boolean;
-  noEmptySelection: boolean;
-  onSelect: ?(rowsIndices: Array<number>, newlySelectedRowIndex: number | null) => void;
-  onSort: null | (sortColumn: number) => void;
-  padding: number;
-  selectedClassName: string;
-  sortColumn: number;
+  footer?: React.Node | (selectedRows: Array<{}>) => React.Node;
+  header?: React.Node | (selectedRows: Array<{}>) => React.Node;
+  multiSelect?: boolean;
+  noEmptySelection?: boolean;
+  onSelect?: (selectedRows: Array<{}>, newlySelectedRows: {} | null) => void;
+  onSort?: (sortColumn: number) => void;
+  padding?: number;
+  selectedClassName?: string;
+  sortColumn?: number;
   split: ColumnCount;
-  tableClassName: string;
-  tableContainerClassName: string | void;
+  tableClassName?: string;
+  tableContainerClassName?: string;
 };
 
 type MasterDetailsState = {
   /** The index for the most-recently selected row, to be displayed in the details pane. */
-  detailsRowIndex: number | null;
+  detailsRow: {} | null;
   /** The indices of the selected rows */
-  selectedRows: Set<number>;
+  selectedRows: Array<{}>;
 };
 
 /**
@@ -160,7 +158,7 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
   constructor(props: MasterDetailsProps) {
     super(props);
     this.state = {
-      detailsRowIndex: null,
+      detailsRow: null,
       selectedRows: [],
     };
     (this: any).selectionChanged = this.selectionChanged.bind(this);
@@ -171,13 +169,13 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
   /**
    * Update the table's selection and update the details view's input.
    */
-  selectionChanged(selectedRowIndices: Array<number>, newlySelectedRowIndex: number | null) {
+  selectionChanged(selectedRows: Array<{}>, newlySelectedRow: {} | null) {
     this.setState({
-      selectedRows: selectedRowIndices,
-      detailsRowIndex: newlySelectedRowIndex,
+      selectedRows,
+      detailsRow: newlySelectedRow,
     }, () => {
       if (this.props.onSelect) {
-        this.props.onSelect(selectedRowIndices, newlySelectedRowIndex);
+        this.props.onSelect(selectedRows, newlySelectedRow);
       }
     });
   }
@@ -217,14 +215,10 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
       tableClassName,
       tableContainerClassName,
     } = this.props;
-    const {
-      selectedRows,
-      detailsRowIndex,
-    } = this.state;
+    const { detailsRow } = this.state;
 
     const detailsWidth = 12 - tableWidth;
     const halfPadding = `${padding / 2}px`;
-    const detailsRow = rows[detailsRowIndex];
 
     return (
       <Grid fluid style={{ padding: 0 }}>
@@ -238,12 +232,11 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
                 onSelect={this.selectionChanged}
                 sortColumn={sortColumn}
                 onSort={onSort}
-                selection={selectedRows}
                 multiSelect={multiSelect}
                 noEmptySelection={noEmptySelection}
                 selectedClassName={selectedClassName}
                 tableClassName={tableClassName}
-                activeRowIndex={detailsRowIndex}
+                activeRowIndex={detailsRow}
                 anchorRowBackgroundColor={anchorRowBackgroundColor}
               />
               {this.renderFooter()}

--- a/src/components/MasterDetails.js
+++ b/src/components/MasterDetails.js
@@ -104,6 +104,10 @@ type MasterDetailsProps = {
    * The class name to apply to the table element. Optional.
    */
   tableClassName: string;
+  /** Optional background color to apply to the last selected row. Only used if multiSelect is specified as well. Takes precedence
+   *  over all other background colors specified through classNames.
+   */
+  lastSelectedRowBackgroundColor: ?string;
 };
 
 type MasterDetailsDefaultProps = {
@@ -221,6 +225,7 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
       details: Detail,
       detailsProps,
       footer,
+      lastSelectedRowBackgroundColor,
       multiSelect,
       noEmptySelection,
       onSort,
@@ -261,6 +266,8 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
                 noEmptySelection={noEmptySelection}
                 selectedClassName={selectedClassName}
                 tableClassName={tableClassName}
+                detailsRowId={detailsRow ? detailsRow.id : ''}
+                lastSelectedRowBackgroundColor={lastSelectedRowBackgroundColor}
               />
               {footer}
             </div>

--- a/src/components/MasterDetails.js
+++ b/src/components/MasterDetails.js
@@ -131,8 +131,6 @@ type MasterDetailsState = {
   selectedRows: Array<string>;
   /** The id for the most-recently selected row, to be displayed in the details pane. */
   detailsRowId: string;
-  /** The object for the most-recently selected row, to be displayed in the details pane.  */
-  detailsRow: any;
 };
 
 /**

--- a/src/components/MasterDetails.js
+++ b/src/components/MasterDetails.js
@@ -107,7 +107,7 @@ type MasterDetailsProps = {
   /** Optional background color to apply to the last selected row. Only used if multiSelect is specified as well. Takes precedence
    *  over all other background colors specified through classNames.
    */
-  lastSelectedRowBackgroundColor: ?string;
+  anchorRowBackgroundColor: ?string;
 };
 
 type MasterDetailsDefaultProps = {
@@ -174,7 +174,7 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
       if (newProps.rows.length === 0) {
         this.setState({
           selectedRows: [],
-          detailsRowId: '',
+          detailsRowId: null,
         });
       } else {
         const ids = newProps.rows.map((row) => {
@@ -200,7 +200,7 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
   selectionChanged(selectedRowIds: Array<string>, newlySelectedRowId: string | null) {
     this.setState({
       selectedRows: selectedRowIds,
-      detailsRowId: newlySelectedRowId || '',
+      detailsRowId: newlySelectedRowId || null,
     }, () => {
       if (this.props.onSelect) {
         this.props.onSelect(selectedRowIds, newlySelectedRowId);
@@ -223,7 +223,7 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
       details: Detail,
       detailsProps,
       footer,
-      lastSelectedRowBackgroundColor,
+      anchorRowBackgroundColor,
       multiSelect,
       noEmptySelection,
       onSort,
@@ -264,8 +264,8 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
                 noEmptySelection={noEmptySelection}
                 selectedClassName={selectedClassName}
                 tableClassName={tableClassName}
-                detailsRowId={detailsRow ? detailsRow.id : ''}
-                lastSelectedRowBackgroundColor={lastSelectedRowBackgroundColor}
+                detailsRowId={this.state.detailsRowId}
+                anchorRowBackgroundColor={anchorRowBackgroundColor}
               />
               {footer}
             </div>

--- a/src/components/MasterDetails.js
+++ b/src/components/MasterDetails.js
@@ -168,13 +168,13 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
   /**
    * Update the table's selection and update the details view's input.
    */
-  selectionChanged(selectedRows: Array<{}>, newlySelectedRow: {} | null) {
+  selectionChanged(selectedRows: Array<{}>, activeRow: {} | null) {
     this.setState({
       selectedRows,
-      detailsRow: newlySelectedRow,
+      detailsRow: activeRow,
     }, () => {
       if (this.props.onSelect) {
-        this.props.onSelect(selectedRows, newlySelectedRow);
+        this.props.onSelect(selectedRows, activeRow);
       }
     });
   }
@@ -199,10 +199,10 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
 
   render() {
     const {
+      anchorRowBackgroundColor,
       columns,
       details: Detail,
       detailsProps,
-      anchorRowBackgroundColor,
       multiSelect,
       noEmptySelection,
       onSort,

--- a/src/components/MasterDetails.js
+++ b/src/components/MasterDetails.js
@@ -168,7 +168,7 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
         selectedRows: [],
         detailsRowId: '',
       });
-    } else {
+    } else { // FIXME: Never perform unconditional side effects in this lifecycle method.
       const ids = newProps.rows.map((row) => {
         return row.id;
       });
@@ -199,37 +199,57 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
   }
 
   render() {
-    const Detail = this.props.details;
-    const tableWidth = this.props.split;
+    const {
+      columns,
+      details: Detail,
+      detailsProps,
+      footer,
+      header,
+      multiSelect,
+      noEmptySelection,
+      onSort,
+      padding,
+      rows,
+      selectedClassName,
+      sortColumn,
+      split: tableWidth,
+      tableClassName,
+      tableContainerClassName,
+    } = this.props;
+    const {
+      detailsRowId,
+      selectedRows,
+    } = this.state;
+
     const detailsWidth = 12 - tableWidth;
-    const halfPadding = `${this.props.padding / 2}px`;
-    const detailsRow = this.props.rows.find((row) => {
-      return row.id === this.state.detailsRowId;
+    const halfPadding = `${padding / 2}px`;
+    const detailsRow = rows.find(({ id }) => {
+      return id === detailsRowId;
     });
 
     return (
       <Grid fluid style={{ padding: 0 }}>
         <Row style={{ margin: 0 }}>
           <Col lg={tableWidth} md={tableWidth} sm={12} xs={12} style={{ paddingLeft: 0, paddingRight: halfPadding }}>
-            <div className={this.props.tableContainerClassName}>
-              {this.props.header}
+            <div className={tableContainerClassName}>
+              {header(selectedRows)}
               <Table
-                columns={this.props.columns}
-                rows={this.props.rows}
+                columns={columns}
+                rows={rows}
                 onSelect={this.selectionChanged}
-                sortColumn={this.props.sortColumn}
-                onSort={this.props.onSort}
-                selection={this.state.selectedRows}
-                multiSelect={this.props.multiSelect}
-                noEmptySelection={this.props.noEmptySelection}
-                selectedClassName={this.props.selectedClassName}
-                tableClassName={this.props.tableClassName}
+                sortColumn={sortColumn}
+                onSort={onSort}
+                selection={selectedRows}
+                multiSelect={multiSelect}
+                noEmptySelection={noEmptySelection}
+                selectedClassName={selectedClassName}
+                tableClassName={tableClassName}
               />
-              {this.props.footer}
+              {footer}
             </div>
           </Col>
           <Col lg={detailsWidth} md={detailsWidth} sm={12} xs={12} style={{ paddingLeft: halfPadding, paddingRight: 0 }}>
-            <Detail {...this.props.detailsProps} data={detailsRow} />
+            <Detail {...detailsProps} data={detailsRow} />
           </Col>
         </Row>
       </Grid>

--- a/src/components/MasterDetails.js
+++ b/src/components/MasterDetails.js
@@ -66,8 +66,7 @@ type MasterDetailsProps = {
    * A header component that can be inserted above the table (but to the left of the
    * details component). For example, this might be used to include controls that help the
    * user filter the list of items in the table. May also be a function that uses selectedRows and
-   * renders a header component. Optional; if not set, the table will be
-   * flush with the top of the details component.
+   * renders a header component. Optional; if not set, the table will be flush with the top of the details component.
    */
   header: any;
   /**
@@ -159,8 +158,8 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
   constructor(props: MasterDetailsProps) {
     super(props);
     this.state = {
-      selectedRows: this.props.rows.length > 0 && this.props.rows[0] ? [this.props.rows[0].id] : [],
-      detailsRowId: this.props.rows.length > 0 && this.props.rows[0] ? this.props.rows[0].id : '',
+      selectedRows: props.rows.length > 0 && props.rows[0] ? [props.rows[0].id] : [],
+      detailsRowId: props.rows.length > 0 && props.rows[0] ? props.rows[0].id : '',
     };
     (this: any).selectionChanged = this.selectionChanged.bind(this);
   }
@@ -207,9 +206,14 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
    * Update the table's selection and update the details view's input.
    */
   selectionChanged(selectedRowIds: Array<string>, newlySelectedRowId: string | null) {
-    if (this.props.onSelect) {
-      this.props.onSelect(selectedRowIds, newlySelectedRowId);
-    }
+    this.setState({
+      selectedRows: selectedRowIds,
+      detailsRowId: newlySelectedRowId || '',
+    }, () => {
+      if (this.props.onSelect) {
+        this.props.onSelect(selectedRowIds, newlySelectedRowId);
+      }
+    });
   }
 
   renderHeader() {

--- a/src/components/SearchRelevancyModel.js
+++ b/src/components/SearchRelevancyModel.js
@@ -60,7 +60,7 @@ export default class SearchRelevancyModel extends React.Component<SearchRelevanc
 
   state: SearchRelevancyModelState;
 
-  componentWillMount() {
+  componentDidMount() {
     // If our parent didn't set a list of models for us
     // to use, ask the server what we should do.
     const uri = `${this.props.baseUri}/rest/relevancyModelApi/getRelevancyModelNames`;

--- a/src/components/Searcher.js
+++ b/src/components/Searcher.js
@@ -341,7 +341,7 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     // When the searcher is first created, this is called.
     // Pull a state object out of the location's query string
     const location = this.props.location;

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -123,9 +123,9 @@ type TableProps = {
    */
   tableClassName: string;
   /**
-   * The id of the row displayed in MasterDetails.
+   * The id of the active row.
    */
-  detailsRowId: string;
+  activeRowId: string;
   /** Optional background color to apply to the last selected row. Only used if multiSelect is specified as well. Takes precedence
    *  over all other background colors specified through classNames.
    */
@@ -134,7 +134,7 @@ type TableProps = {
 
 type TableDefaultProps = {
   bordered: boolean;
-  detailsRowId: string;
+  activeRowId: string;
   multiSelect: boolean;
   noEmptySelection: boolean;
   onSelect: null | (selectedRowsIds: Array<string>, newlySelectedRowId: string | null) => void;
@@ -173,7 +173,7 @@ type TableState = {
 export default class Table extends React.Component<TableDefaultProps, TableProps, TableState> {
   static defaultProps = {
     bordered: false,
-    detailsRowId: '',
+    activeRowId: '',
     multiSelect: false,
     noEmptySelection: false,
     onSelect: null,
@@ -289,7 +289,7 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
     const ctrlKeyPressed = ctrlKeyDown;
     const newSelectedRowIndices = prevSelectedRowIndices;
 
-    const { multiSelect, noEmptySelection, onSelect, detailsRowId } = this.props;
+    const { multiSelect, noEmptySelection, onSelect, activeRowId } = this.props;
 
     if (!rowData) {
       return false;
@@ -302,7 +302,7 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
             selectedRowIndices: new Set([rowData.index]),
             anchorRowIndex: rowData.index,
           });
-          onSelect([rowData.id], detailsRowId);
+          onSelect([rowData.id], activeRowId);
           return true;
         }
         // The shift key was pressed. The anchor row and active rows do not change. All previously selected rows are purged.
@@ -321,7 +321,7 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
         this.setState({
           newSelectedRowIndices,
         });
-        onSelect(newSelectedRowIds, detailsRowId);
+        onSelect(newSelectedRowIds, activeRowId);
 
         return true;
       } else if (ctrlKeyPressed) {
@@ -347,7 +347,7 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
           // This row is not the only selection, deselect it.
           newSelectedRowIndices.delete(rowData.index);
           // Is the row we're deselecting the active row?
-          const updateActiveRow = rowData.id === detailsRowId;
+          const updateActiveRow = rowData.id === activeRowId;
           // Is the row we're deselecting the anchor row?
           const updateAnchorRow = rowData.index === anchorRowIndex;
           if (updateActiveRow || updateAnchorRow) {
@@ -364,7 +364,7 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
                 return Math.min(currentRowIndex, minimumRowIndex);
               }, Infinity)
             ].id
-            : detailsRowId;
+            : activeRowId;
 
             const newSelectedRowIds = this.getSelectedIds(newSelectedRowIndices);
             this.setState({
@@ -379,7 +379,7 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
             selectedRowIndices: newSelectedRowIndices,
           });
           const newSelectedRowIds = this.getSelectedIds(newSelectedRowIndices);
-          onSelect(newSelectedRowIds, detailsRowId);
+          onSelect(newSelectedRowIds, activeRowId);
           return true;
         }
         // This row was not previously selected. The new row becomes the anchor row, but the active row does not change.
@@ -390,7 +390,7 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
           selectedRowIndices: newSelectedRowIndices,
           anchorRowIndex: rowData.index,
         });
-        onSelect(newSelectedRowIds, detailsRowId);
+        onSelect(newSelectedRowIds, activeRowId);
         return true;
       }
       // If no modifier keys were pressed, all previously selected indices are cleared and the row selected becomes the
@@ -406,7 +406,7 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
 
     // multiSelect is not enabled
     // if this row is already the currently selected row,
-    if (detailsRowId === rowData.id) {
+    if (activeRowId === rowData.id) {
       // if we don't allow empty selection
       if (noEmptySelection) {
         // do nothing
@@ -445,7 +445,7 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
   }
 
   render() {
-    const { multiSelect, selection, detailsRowId, anchorRowBackgroundColor } = this.props;
+    const { multiSelect, selection, activeRowId, anchorRowBackgroundColor } = this.props;
     const { selectedRowIndices } = this.state;
 
     let selectedRowIds;
@@ -475,7 +475,7 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
       clickToSelect: true,
       className: this.props.selectedClassName,
       bgColor: (row) => {
-        if (multiSelect && row.id === detailsRowId && anchorRowBackgroundColor) {
+        if (multiSelect && row.id === activeRowId && anchorRowBackgroundColor) {
           return anchorRowBackgroundColor;
         }
         return null;

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -131,7 +131,8 @@ type TableProps = {
    * The comparator is given two row objects to compare. If the rows are equal, the function should return true.
    * If the two rows are not equal, the function should return false.
    */
-  rowComparator: (rowA: {}, rowB: {}) => boolean;
+  // eslint-disable-next-line react/no-unused-prop-types
+  rowComparator: (rowA: {}, rowB: {}) => boolean; // This prop is referenced as a newProp in componentWillReceiveProps.
 };
 
 type TableDefaultProps = {

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -180,9 +180,11 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
   constructor(props: TableProps) {
     super(props);
     this.state = {
-      sortedRows: this.props.rows.map((row, index) => {
-        return { ...row, index };
-      }),
+      sortedRows: props.rows && props.rows.length > 0
+        ? props.rows.map((row, index) => {
+          return { ...row, index };
+        })
+        : [],
       selectedRowIndices: new Set([0]),
       controlKeyDown: false,
       lastSelectedRowIndex: null,
@@ -204,9 +206,11 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
     if (!ObjectUtils.arrayEquals(newProps.rows, this.props.rows)) {
       // Reset the sorted rows if the actual rows have changed.
       this.setState({
-        sortedRows: newProps.rows.map((row, index) => {
-          return { ...row, index };
-        }),
+        sortedRows: newProps.rows && newProps.rows.length > 0
+          ? newProps.rows.map((row, index) => {
+            return { ...row, index };
+          })
+          : [],
       });
     }
   }
@@ -214,7 +218,6 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
   componentWillUnmount() {
     if (this.props.multiSelect) {
       window.removeEventListener('keydown', this.keyDown);
-      // window.removeEventListener('keyup', this.keyUp);
     }
   }
 

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -146,7 +146,7 @@ type TableDefaultProps = {
 };
 
 type TableState = {
-  /** The index of the anchor row. Only relevant with multiSelect option enabled.*/
+  /** The index of the anchor row. Only relevant with multiSelect option enabled. */
   anchorRowIndex: number | null;
   /** Indicates whether or not the shift key is pressed down. Only relevant with multiSelect option enabled. */
   shiftKeyDown: boolean;
@@ -214,7 +214,7 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
   componentDidMount() {
     if (this.props.multiSelect) {
       document.addEventListener('keydown', this.keyDown);
-      document.addEventListener('keyup', this.keyup);
+      document.addEventListener('keyup', this.keyUp);
     }
   }
 
@@ -234,7 +234,7 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
   componentWillUnmount() {
     if (this.props.multiSelect) {
       document.removeEventListener('keydown', this.keyDown);
-      document.removeEventListener('keyup', this.keyup);
+      document.removeEventListener('keyup', this.keyUp);
     }
   }
 
@@ -255,15 +255,8 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
       selectedRowArray.push(rowIndex);
     });
     const selectedRowIds = selectedRowArray.map((rowIndex) => {
-      console.log('rowIndex: ', rowIndex);
-      console.log('sortedRows[rowIndex]: ', sortedRows[rowIndex]);
       return sortedRows[rowIndex] ? `${sortedRows[rowIndex].id}` : null;
     });
-    console.group('getSelectedIds()');
-    console.log('newSelectedRowIndices: ', newSelectedRowIndices);
-    console.log('selectedRowArray: ', selectedRowArray);
-    console.log('selectedRowIds: ', selectedRowIds);
-    console.groupEnd();
     return selectedRowIds;
   }
 
@@ -276,10 +269,10 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
   }
 
   keyUp = (e: KeyboardEvent) => {
-    if (e.shiftKey || e.ctrlKey || e.metaKey) {
-      const shiftKeyDown = !e.shiftKey;
-      const ctrlKeyDown = !(e.ctrlKey || e.metaKey);
-      this.setState({ shiftKeyDown, ctrlKeyDown });
+    const shiftKeyUp = e.key === 'Shift';
+    const ctrlKeyUp = e.key === 'Control' || e.key === 'Meta';
+    if (shiftKeyUp || ctrlKeyUp) {
+      this.setState({ shiftKeyDown: false, ctrlKeyDown: false });
     }
   }
 
@@ -296,11 +289,6 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
     const newSelectedRowIndices = prevSelectedRowIndices;
 
     const { multiSelect, selection, noEmptySelection, onSelect } = this.props;
-
-    console.group('rowSelect');
-    console.log('shiftKeyPressed: ', shiftKeyPressed);
-    console.log('ctrlKeyPressed: ', ctrlKeyPressed);
-    console.groupEnd();
 
     if (!rowData) {
       console.error('Error: <Table /> rowSelect called without providing rowData param.');
@@ -331,7 +319,6 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
         }
 
         this.setState({
-          shiftKeyDown: false,
           selectedRowIndices: newSelectedRowIndices,
         });
         onSelect(keyboardSelectedIds, selection);
@@ -365,7 +352,6 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
 
             const newSelectedRowIds = this.getSelectedIds(newSelectedRowIndices);
             this.setState({
-              ctrlKeyDown: false,
               selectedRowIndices: newSelectedRowIndices,
               anchorRowIndex: newAnchorRowIndex,
             });
@@ -374,7 +360,6 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
           }
             // If the row we're deselecting is not the anchor row or active row, just deselect it.
           this.setState({
-            ctrlKeyDown: false,
             selectedRowIndices: newSelectedRowIndices,
           });
           const newSelectedRowIds = this.getSelectedIds(newSelectedRowIndices);
@@ -386,7 +371,6 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
         newSelectedRowIndices.add(rowData.index);
         const newSelectedRowIds = this.getSelectedIds(newSelectedRowIndices);
         this.setState({
-          ctrlKeyDown: false,
           selectedRowIndices: newSelectedRowIndices,
           anchorRowIndex: rowData.index,
         });

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -122,17 +122,26 @@ type TableProps = {
    * The class name to apply to the table element. Optional.
    */
   tableClassName: string;
+  /**
+   * The id of the row displayed in MasterDetails.
+   */
+  detailsRowId: string;
+    /** Optional background color to apply to the last selected row. Only used if multiSelect is specified as well. Takes precedence
+   *  over all other background colors specified through classNames.
+   */
+  lastSelectedRowBackgroundColor: ?string;
 };
 
 type TableDefaultProps = {
-  onSelect: null | (selectedRowsIds: Array<string>, newlySelectedRowId: string | null) => void;
-  selection: Array<srting>;
-  multiSelect: boolean;
-  sortColumn: number;
-  onSort: null | (sortColumn: number) => void;
-  noEmptySelection: boolean;
   bordered: boolean;
+  detailsRowId: string;
+  multiSelect: boolean;
+  noEmptySelection: boolean;
+  onSelect: null | (selectedRowsIds: Array<string>, newlySelectedRowId: string | null) => void;
+  onSort: null | (sortColumn: number) => void;
   selectedClassName: string;
+  selection: Array<srting>;
+  sortColumn: number;
   tableClassName: string;
 };
 
@@ -156,14 +165,15 @@ type TableState = {
  */
 export default class Table extends React.Component<TableDefaultProps, TableProps, TableState> {
   static defaultProps = {
-    onSelect: null,
-    selection: [],
-    multiSelect: false,
-    sortColumn: 0,
-    onSort: null,
-    noEmptySelection: false,
     bordered: false,
+    detailsRowId: '',
+    multiSelect: false,
+    noEmptySelection: false,
+    onSelect: null,
+    onSort: null,
     selectedClassName: 'attivio-table-row-selected',
+    selection: [],
+    sortColumn: 0,
     tableClassName: 'table table-striped attivio-table attivio-table-sm',
   };
 
@@ -198,7 +208,7 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
 
   componentDidMount() {
     if (this.props.multiSelect) {
-      window.addEventListener('keydown', this.keyDown);
+      document.addEventListener('keydown', this.keyDown);
     }
   }
 
@@ -217,14 +227,11 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
 
   componentWillUnmount() {
     if (this.props.multiSelect) {
-      window.removeEventListener('keydown', this.keyDown);
+      document.removeEventListener('keydown', this.keyDown);
     }
   }
 
   keyDown = (e: KeyboardEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-
     if (this.props.multiSelect && (e.ctrlKey || e.metaKey)) {
       this.setState({ controlKeyDown: true });
     }
@@ -355,7 +362,7 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
   }
 
   render() {
-    const { multiSelect, selection } = this.props;
+    const { multiSelect, selection, detailsRowId, lastSelectedRowBackgroundColor } = this.props;
     const { selectedRowIndices } = this.state;
 
     let selectedRowIds;
@@ -384,6 +391,12 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
       onSelect: this.rowSelect,
       clickToSelect: true,
       className: this.props.selectedClassName,
+      bgColor: (row) => {
+        if (multiSelect && row.id === detailsRowId && lastSelectedRowBackgroundColor) {
+          return lastSelectedRowBackgroundColor;
+        }
+        return null;
+      },
       hideSelectColumn: true,
       selected: selectedRowIds,
     } : null;

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -336,7 +336,8 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
             if (noEmptySelection) {
               return false;
             }
-            // The row is already selected, and it's the only selection, but the table allows no selections, so clear out selections.
+            // The row is already selected, and it's the only selection, but the table allows no selections,
+            // so clear out selections.
             this.setState({
               selectedRowIndices: new Set([]),
               anchorRowIndex: null,

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -136,12 +136,13 @@ type TableProps = {
 };
 
 type TableDefaultProps = {
-  bordered?: boolean;
-  multiSelect?: boolean;
-  noEmptySelection?: boolean;
-  selectedClassName?: string;
-  sortColumn?: number;
-  tableClassName?: string;
+  bordered: boolean;
+  multiSelect: boolean;
+  noEmptySelection: boolean;
+  rows: Array<{}>;
+  selectedClassName: string;
+  sortColumn: number;
+  tableClassName: string;
 };
 
 type TableState = {
@@ -174,6 +175,7 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
     bordered: false,
     multiSelect: false,
     noEmptySelection: false,
+    rows: [],
     selectedClassName: 'attivio-table-row-selected',
     sortColumn: 0,
     tableClassName: 'table table-striped attivio-table attivio-table-sm',
@@ -228,7 +230,10 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
 
   componentWillReceiveProps(newProps: TableProps) {
     // If a rowComparator is specified, use it, otherwise, do a deep row comparison and reset selection if anything changed.
-    if ((newProps.rowComparator && !isEqualWith(newProps.rows, this.props.rows, newProps.rowComparator))
+    if ((newProps.rows && this.props.rows && newProps.rows.length !== this.props.rows.length)
+      || (newProps.rows && !this.props.rows)
+      || (!newProps.rows && this.props.rows)
+      || (newProps.rowComparator && !isEqualWith(newProps.rows, this.props.rows, newProps.rowComparator))
       || (!newProps.rowComparator && !isEqual(newProps.rows, this.props.rows))
     ) {
       // Reset the sorted rows if the actual rows have changed.

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -146,7 +146,7 @@ type TableDefaultProps = {
 };
 
 type TableState = {
-  controlKeyDown: Boolean;
+  shiftKeyDown: Boolean;
   lastSelectedRowIndex: number | null;
   /**
    * The sorted list of rows. If not sorting in the table, this will always just be
@@ -196,7 +196,7 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
         })
         : [],
       selectedRowIndices: new Set([0]),
-      controlKeyDown: false,
+      shiftKeyDown: false,
       lastSelectedRowIndex: 0,
     };
     (this: any).handleSort = this.handleSort.bind(this);
@@ -232,8 +232,8 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
   }
 
   keyDown = (e: KeyboardEvent) => {
-    if (this.props.multiSelect && (e.ctrlKey || e.metaKey)) {
-      this.setState({ controlKeyDown: true });
+    if (this.props.multiSelect && e.shiftKey) {
+      this.setState({ shiftKeyDown: true });
     }
   }
 
@@ -241,7 +241,7 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
     const { multiSelect, selection, noEmptySelection, onSelect } = this.props;
     const {
       selectedRowIndices: prevSelectedRowIndices,
-      controlKeyDown,
+      shiftKeyDown,
       lastSelectedRowIndex: prevLastSelectedRowIndex,
       sortedRows,
     } = this.state;
@@ -260,12 +260,12 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
 
         this.setState({
           selectedRowIndices: newSelectedRowIndices,
-          controlKeyDown: false,
+          shiftKeyDown: false,
         });
       } else {
         newSelectedRowIndices.add(rowData.index);
 
-        if (controlKeyDown && (prevLastSelectedRowIndex || prevLastSelectedRowIndex === 0)) {
+        if (shiftKeyDown && (prevLastSelectedRowIndex || prevLastSelectedRowIndex === 0)) {
           const count = rowData.index - prevLastSelectedRowIndex;
 
           const startIndex = count > 0 ? prevLastSelectedRowIndex + 1 : rowData.index + 1;
@@ -286,7 +286,7 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
 
         this.setState({
           selectedRowIndices: newSelectedRowIndices,
-          controlKeyDown: false,
+          shiftKeyDown: false,
           lastSelectedRowIndex: rowData.index,
         });
       }

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -482,6 +482,7 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
   }
 
   handleSort = (colName: string, order: 'asc' | 'desc') => {
+    const { rows, noEmptySelection, onSelect } = this.props;
     let colNum = 0;
     this.props.columns.forEach((col: TableColumn, index: number) => {
       if (col.title === colName || (typeof col.render === 'string' && col.render === colName)) {
@@ -491,6 +492,27 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
     if (order === 'desc') {
       colNum = -colNum;
     }
+    const sortedRows = rows && rows.length > 0
+      ? rows.map((row, index) => {
+        return { ...row, index };
+      })
+      : [];
+
+    // Reset table selection.
+    const tableContainsRows = this.state.sortedRows.length > 0;
+
+    const defaultIndex = noEmptySelection && tableContainsRows ? 0 : null;
+    if (onSelect) {
+      const selectedRows = defaultIndex ? [defaultIndex] : [];
+      onSelect(selectedRows, defaultIndex);
+    }
+    const selectedRowIndices = defaultIndex ? new Set([defaultIndex]) : new Set([]);
+    this.setState({
+      activeRowIndex: defaultIndex,
+      anchorRowIndex: defaultIndex,
+      selectedRowIndices,
+      sortedRows,
+    });
     this.props.onSort(colNum);
   }
 

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -227,6 +227,7 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
             return { ...row, index };
           })
           : [],
+        selectedRowIndices: new Set([]),
       });
     }
   }

--- a/src/components/Toggle.js
+++ b/src/components/Toggle.js
@@ -28,9 +28,14 @@ export default class Toggle extends React.Component<void, ToggleProps, void> {
 
   render() {
     const { customClassName = '' } = this.props;
-    const className = customClassName ? `attivio-smalltoolbar-btn ${customClassName}` : 'attivio-smalltoolbar-btn';
+    const className = customClassName || 'attivio-smalltoolbar-btn';
+
     return (
-      <a href className={className} onClick={this.handleClick}>
+      <a
+        href
+        className={className}
+        onClick={this.handleClick}
+      >
         {this.props.children}
       </a>
     );

--- a/src/components/Toggle.js
+++ b/src/components/Toggle.js
@@ -7,6 +7,7 @@ type ToggleProps = {
   onClick: (e: Event) => void;
   /** The child components */
   children: Children;
+  customClassName: ?string;
 };
 
 /**
@@ -26,8 +27,10 @@ export default class Toggle extends React.Component<void, ToggleProps, void> {
   }
 
   render() {
+    const { customClassName = '' } = this.props;
+    const className = customClassName ? `attivio-smalltoolbar-btn ${customClassName}` : 'attivio-smalltoolbar-btn';
     return (
-      <a href className="attivio-smalltoolbar-btn" onClick={this.handleClick}>
+      <a href className={className} onClick={this.handleClick}>
         {this.props.children}
       </a>
     );


### PR DESCRIPTION
Addresses [PLAT-42929](https://jira.attivio.com/browse/PLAT-42929).

Adds support for keyboard multiselect in Table and MasterDetails using shift key for selecting multiple rows and ctrl/meta key for selecting individual rows. 
This new selection support uses the concept of an anchor row. There can only be one anchor row. It may or may not be the same as the active row displayed in MasterDetails. The anchor row will always be the last row clicked without a modifier or with the ctrl key. Clicks made with the shift key do not change the anchor row. The anchor row is used to determine what rows will be selected when the shift key is used for multiselect.
The selections behavior largely follows Outlooks selection behavior with one intentional difference.
See the following pdfs for detailed differences.
[Outlook Selection Behavior.pdf](https://github.com/attivio/suit/files/2911116/Outlook.Selection.Behavior.pdf)
[Table Selection Behavior.pdf](https://github.com/attivio/suit/files/2911117/Table.Selection.Behavior.pdf)

This is a breaking change for the Table multiselect behavior. Clicking a row will no longer make multiple selections unless a ctrl/meta or shift key is pressed down.

If multiselect is true, there as an additional optional prop that may be passed to specify the background color for the row corresponding to the current detail row being displayed. This change is backwards compatible and opt-in. If users omit the new prop, the current behavior won't change.

I updated the table header prop to support either a render function or a component as it does today. Users passing in a component can continue to do so.

Performance improvements: 
Updates the Configurable component to no longer use `componentWillReceiveProps`. Because configuration options do not change, setting these on component mount is sufficient. The use of that lifecycle function was triggering cascading updates, which frequently resulted in an infinite cycle of rerenders. Anytime any child component received an update (triggered by state or prop changes), componentWillReceiveProps was called and unconditionally rewrote the incoming props to state, triggering a subsequent state update, and a subsequent call of componentWillReceiveProps.
Because of the wide use of this component, this should be a significant performance improvement. However, most use cases won't notice a change. Only areas using virtualization or managing large data sets, or data hungry loads such as video would likely see a difference.
This change is backwards compatible and is invisible to library consumers - configuration can still be specified as it is today.

I updated references to `componentWillMount` (which is being deprecated) to instead use `componentDidMount` and added `FIXME` notations to various usages of `componentDidMount` where state is being set in that lifecycle method and to instances where `componentWillReceiveProps` is setting state without first doing a prop change comparison.
https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html