### PR TITLE
Feat plat 42929 a

### DIFF
--- a/documentation/components/MasterDetails.md
+++ b/documentation/components/MasterDetails.md
@@ -13,8 +13,8 @@ __1:__ A simple master detail example using the dummy &lt;Details&gt; component 
   />
 ```
 
-__2:__ A master detail example using the dummy &lt;Details&gt; component on the right side, 
-multiselect table option, that always requires a table selection.
+__2:__ A master detail example using the dummy &lt;Details&gt; component on the right side and
+multiselect table option that always requires a table selection.
 
 ```jsx
   const tableData = require('../sampleData/TableData').default;

--- a/documentation/components/MasterDetails.md
+++ b/documentation/components/MasterDetails.md
@@ -1,6 +1,5 @@
 #### Examples:
 
-
 __1:__ A simple master detail example using the dummy &lt;Details&gt; component on the right side.
 
 ```jsx
@@ -11,10 +10,29 @@ __1:__ A simple master detail example using the dummy &lt;Details&gt; component 
     columns={tableData.experts.columns}
     rows={tableData.experts.rows}
     details={Details}
-  /> 
+  />
 ```
 
-__2:__ Another example showing the use of a header and footer and with a 50-50 split, widthwise, between
+__2:__ A master detail example using the dummy &lt;Details&gt; component on the right side, 
+multiselect table option, that always requires a table selection.
+
+```jsx
+  const tableData = require('../sampleData/TableData').default;
+  const Details = require('../../src/components/Details').default;
+
+  <MasterDetails
+    columns={tableData.experts.columns}
+    rows={tableData.experts.rows}
+    details={Details}
+    rowComparator={(rowA, rowB) => rowA.id === rowB.id}
+    multiSelect
+    activeRowBackgroundColor="#d08afc"
+    multiSelectBackgroundColor="#dcaef9"
+    noEmptySelection
+  />
+```
+
+__3:__ Another example showing the use of a header and footer and with a 50-50 split, widthwise, between
 the table and details, along with 20 pixels of padding between them.
 
 ```jsx
@@ -33,10 +51,10 @@ the table and details, along with 20 pixels of padding between them.
     )}
     split={6}
     padding={20}
-  /> 
+  />
 ```
 
-__3:__ A multi-select variation with a custom details component. In real life, it's recommended that you
+__4:__ A multi-select variation with a custom details component. In real life, it's recommended that you
 create a full class-based component for the details pane.
 
 ```jsx
@@ -101,5 +119,5 @@ create a full class-based component for the details pane.
     columns={tableData.experts.columns}
     rows={tableData.experts.rows}
     details={details}
-  /> 
+  />
 ```

--- a/documentation/components/Table.md
+++ b/documentation/components/Table.md
@@ -1,48 +1,80 @@
 #### Examples:
 
-
 __1:__ Simple table allowing multiple selection.
 
 ```jsx
   const tableData = require('../sampleData/TableData').default;
   initialState = {
-    selectedRows: tableData.customerEngagementRows[0],
+    activeRow: tableData.customerEngagementRows[0],
+    selectedRows: [tableData.customerEngagementRows[0], tableData.customerEngagementRows[1]],
   };
+
   <Table
     columns={tableData.customerEngagementSimpleColumns}
     rows={tableData.customerEngagementRows}
-    onSelect={(row) => {
-      setState({ selectedRows: row });
+    onSelect={(selectedRows, activeRow) => {
+      setState({ selectedRows, activeRow });
     }}
-    selection={state.selectedRows}
     multiSelect
-  /> 
+    activeRowBackgroundColor="#d08afc"
+    multiSelectBackgroundColor="#dcaef9"
+    rowComparator={(rowA, rowB) => {
+      return rowA.id === rowB.id
+    }}
+  />
 ```
 
-__2:__ Single-selection table with a border.
+__3:__ Simple table allowing multiple selection that requires a row to always be selected.
 
 ```jsx
   const tableData = require('../sampleData/TableData').default;
   initialState = {
-    selectedRows: tableData.customerEngagementRows[0],
+    activeRow: tableData.customerEngagementRows[0],
+    selectedRows: [tableData.customerEngagementRows[0], tableData.customerEngagementRows[1]],
+  };
+
+  <Table
+    columns={tableData.customerEngagementSimpleColumns}
+    rows={tableData.customerEngagementRows}
+    onSelect={(selectedRows, activeRow) => {
+      // The table will support multiselect without this function.
+      // Use this function to get access to the selected rows.
+      setState({ selectedRows, activeRow });
+    }}
+    multiSelect
+    noEmptySelection
+    rowComparator={(rowA, rowB) => {
+      return rowA.id === rowB.id
+    }}
+  />
+```
+
+__4:__ Single-selection table with a border.
+
+```jsx
+  const tableData = require('../sampleData/TableData').default;
+  initialState = {
+    selectedRows: [tableData.customerEngagementRows[0]],
   };
   <Table
     columns={tableData.customerEngagementSimpleColumns}
     rows={tableData.customerEngagementRows}
-    onSelect={(row) => {
-      setState({ selectedRows: row });
+    onSelect={(selectedRows) => {
+      setState({ selectedRows});
     }}
-    selection={state.selectedRows}
+    rowComparator={(rowA, rowB) => {
+      return rowA.id === rowB.id
+    }}
     bordered
-  /> 
+  />
 ```
 
-__3:__ Table with a custom cell renderer for the Self-Service column showing percentage bars...
+__5:__ Table with a custom cell renderer for the Self-Service column showing percentage bars...
 
 ```jsx
   const tableData = require('../sampleData/TableData').default;
   initialState = {
-    selectedRow: tableData.customerEngagementRows[0],
+    selectedRows: [tableData.customerEngagementRows[0]],
   };
   const cols = tableData.customerEngagementSimpleColumns.slice();
   const maxSelfServe = tableData.customerEngagementRows.reduce((acc, row) => {
@@ -69,19 +101,18 @@ __3:__ Table with a custom cell renderer for the Self-Service column showing per
   <Table
     columns={cols}
     rows={tableData.customerEngagementRows}
-    onSelect={(row) => {
-      setState({ selectedRow: row });
+    onSelect={(selectedRows) => {
+      setState({ selectedRows });
     }}
-    selection={state.selectedRow}
-  /> 
+  />
 ```
 
-__4:__ Table with sortable columms handled by a global handler (useful when sorting in the back-end code).
+__6:__ Table with sortable columms handled by a global handler (useful when sorting in the back-end code).
 
 ```jsx
   const tableData = require('../sampleData/TableData').default;
   initialState = {
-    selectedRow: tableData.customerEngagementRows[0],
+    selectedRows: [tableData.customerEngagementRows[0]],
     sortCol: 0,
     rows: tableData.customerEngagementRows.slice(),
   };
@@ -91,10 +122,9 @@ __4:__ Table with sortable columms handled by a global handler (useful when sort
   <Table
     columns={columns}
     rows={state.rows}
-    onSelect={(row) => {
-      setState({ selectedRow: row });
+    onSelect={(selectedRows) => {
+      setState({ selectedRows });
     }}
-    selection={state.selectedRow}
     sortColumn={state.sortCol}
     onSort={(col) => {
       if (col !== 0) {
@@ -122,15 +152,15 @@ __4:__ Table with sortable columms handled by a global handler (useful when sort
         });
       }
     }}
-  /> 
+  />
 ```
 
-__5:__ Table with sortable columms with sorting handled by the columns themselves.
+__7:__ Table with sortable columms with sorting handled by the columns themselves.
 
 ```jsx
   const tableData = require('../sampleData/TableData').default;
   initialState = {
-    selectedRow: tableData.customerEngagementRows[0],
+    selectedRows: [tableData.customerEngagementRows[0]],
     sortCol: 0,
   };
   const numberToText = (n) => {
@@ -204,9 +234,8 @@ __5:__ Table with sortable columms with sorting handled by the columns themselve
   <Table
     columns={columns}
     rows={tableData.customerEngagementRows}
-    onSelect={(row) => {
-      setState({ selectedRow: row });
+    onSelect={(selectedRows) => {
+      setState({ selectedRows });
     }}
-    selection={state.selectedRow}
-  /> 
+  />
 ```

--- a/documentation/components/Table.md
+++ b/documentation/components/Table.md
@@ -24,7 +24,7 @@ __1:__ Simple table allowing multiple selection.
   />
 ```
 
-__3:__ Simple table allowing multiple selection that requires a row to always be selected.
+__2:__ Simple table allowing multiple selection that requires a row to always be selected.
 
 ```jsx
   const tableData = require('../sampleData/TableData').default;
@@ -49,7 +49,7 @@ __3:__ Simple table allowing multiple selection that requires a row to always be
   />
 ```
 
-__4:__ Single-selection table with a border.
+__3:__ Single-selection table with a border.
 
 ```jsx
   const tableData = require('../sampleData/TableData').default;
@@ -69,7 +69,7 @@ __4:__ Single-selection table with a border.
   />
 ```
 
-__5:__ Table with a custom cell renderer for the Self-Service column showing percentage bars...
+__4:__ Table with a custom cell renderer for the Self-Service column showing percentage bars...
 
 ```jsx
   const tableData = require('../sampleData/TableData').default;
@@ -107,7 +107,7 @@ __5:__ Table with a custom cell renderer for the Self-Service column showing per
   />
 ```
 
-__6:__ Table with sortable columms handled by a global handler (useful when sorting in the back-end code).
+__5:__ Table with sortable columms handled by a global handler (useful when sorting in the back-end code).
 
 ```jsx
   const tableData = require('../sampleData/TableData').default;
@@ -155,7 +155,7 @@ __6:__ Table with sortable columms handled by a global handler (useful when sort
   />
 ```
 
-__7:__ Table with sortable columms with sorting handled by the columns themselves.
+__6:__ Table with sortable columms with sorting handled by the columns themselves.
 
 ```jsx
   const tableData = require('../sampleData/TableData').default;

--- a/documentation/style/custom-general-overrides.less
+++ b/documentation/style/custom-general-overrides.less
@@ -32,7 +32,6 @@ a.mapboxgl-ctrl-logo {
   word-break: break-all;
 }
 
-
 .attivio-tabpanel-radio > .nav-tabs .attivio-icon{
   float: left;
 }
@@ -130,4 +129,15 @@ dd{
 .label.label-primary a {
   color: lighten(@gray-base, 80%);
   font-weight: normal;
+}
+
+.attivio-table-row {
+  ::selection {
+    background: inherit;
+  }
+}
+
+.attivio-table-no-outline tr td {
+  outline: none;
+  cursor: pointer;
 }

--- a/src/components/MasterDetails.js
+++ b/src/components/MasterDetails.js
@@ -38,7 +38,7 @@ type MasterDetailsProps = {
    */
   multiSelect?: boolean;
   /**
-   * This callback is called when the user changes the selection in the table. However the
+   * This optional callback is called when the user changes the selection in the table. However the
    * Table component is responsible for maintaining the selection in the table; this callback
    * is just a "courtesy" so the parent can do something such as change the enablement of buttons,
    * etc., based on the selection. See the onSelect property of the Table component for more details.
@@ -105,6 +105,11 @@ type MasterDetailsProps = {
    */
   activeRowBackgroundColor?: string;
   /**
+   *  Optional background color to apply all selected rows except for the active row. Only used if multiSelect is specified as well.
+   *  Takes precedence over all other background colors specified through classNames.
+   */
+  multiSelectBackgroundColor?: string;
+  /**
    * Row comparator function passed through to the Table component. See Table component for details.
    */
   rowComparator: (rowA: {}, rowB: {}) => boolean;
@@ -144,10 +149,10 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
     multiSelect: false,
     noEmptySelection: false,
     padding: 0,
-    selectedClassName: 'attivio-table-row-selected',
+    selectedClassName: 'attivio-table-row-selected attivio-table-row',
     sortColumn: 0,
     split: 8,
-    tableClassName: 'table table-striped attivio-table attivio-table-sm',
+    tableClassName: 'table table-striped attivio-table attivio-table-sm attivio-table-no-outline',
     tableContainerClassName: '',
   };
 
@@ -203,6 +208,7 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
       details: Detail,
       detailsProps,
       multiSelect,
+      multiSelectBackgroundColor,
       noEmptySelection,
       onSort,
       padding = 0,
@@ -236,6 +242,7 @@ export default class MasterDetails extends React.Component<MasterDetailsDefaultP
                 selectedClassName={selectedClassName}
                 tableClassName={tableClassName}
                 activeRowBackgroundColor={activeRowBackgroundColor}
+                multiSelectBackgroundColor={multiSelectBackgroundColor}
                 rowComparator={rowComparator}
               />
               {this.renderFooter()}

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -176,9 +176,9 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
     multiSelect: false,
     noEmptySelection: false,
     rows: [],
-    selectedClassName: 'attivio-table-row-selected',
+    selectedClassName: 'attivio-table-row-selected attivio-table-row',
     sortColumn: 0,
-    tableClassName: 'table table-striped attivio-table attivio-table-sm',
+    tableClassName: 'table table-striped attivio-table attivio-table-sm attivio-table-no-outline ',
   };
 
   static makeCustomRenderer(column) {

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -178,7 +178,7 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
     rows: [],
     selectedClassName: 'attivio-table-row-selected attivio-table-row',
     sortColumn: 0,
-    tableClassName: 'table table-striped attivio-table attivio-table-sm attivio-table-no-outline ',
+    tableClassName: 'table table-striped attivio-table attivio-table-sm attivio-table-no-outline',
   };
 
   static makeCustomRenderer(column) {


### PR DESCRIPTION
Update style guide to reflect multiselect changes to `<Table />` and `<MasterDetails />`.

Also eliminated the outline on user click that appeared on rows. Previously, I was handling that in Connector Admin, but it's better to take care of it here. I also added an optional prop `multiSelectBackgroundColor`. Now `activeRowBackgroundColor` always applies to the active row, regardless if the user has elected to use `multiSelect`. 