### PR TITLE
Add a new Spinner Component and changes to Searcher to keep track of when a search is being performed

### DIFF
--- a/documentation/components/Spinner.md
+++ b/documentation/components/Spinner.md
@@ -1,0 +1,13 @@
+#### Examples:
+
+__1.__ Simple spinner with height and width of 100px and with the label 'Loading Results...' below it.
+These props are also configurable from the configuration file
+
+```jsx
+  <Spinner
+    spinner={'img/spinner.gif'}
+    spinnerHeight={'100px'}
+    spinnerWidth={'100px'}
+    spinnerLabel={'Loading Results...'}
+  />
+```

--- a/src/components/Searcher.js
+++ b/src/components/Searcher.js
@@ -41,90 +41,90 @@ import Configuration from '../components/Configuration';
 */
 
 type SearcherProps = {
-  location: PropTypes.object.isRequired;
-  history: PropTypes.object.isRequired;
+  location: PropTypes.object.isRequired,
+  history: PropTypes.object.isRequired,
 
   /**
    * The engine backing the SUIT application. Defaults to 'attivio'.
-   * Set to 'solr' or 'elastic' to use one of those engines instesd.
+   * Set to 'solr' or 'elastic' to use one of those engines instead.
    */
-  searchEngineType: 'attivio' | 'solr' | 'elastic';
+  searchEngineType: 'attivio' | 'solr' | 'elastic',
   /**
    * If a search engine than 'attivio' is specified, this property contains
    * configuration mappings and other options for it. It is ignored when the
    * engine is 'attivio'.
    */
-  customOptions: any;
+  customOptions: any,
   /**
    * Optional. The location of the node through which to interact with Attivio.
    * Defaults to the value in the configuration.
    */
-  baseUri: string;
+  baseUri: string,
   /** The workflow to use when performing the search. Defaults to the "search" workflow. */
-  searchWorkflow: string;
+  searchWorkflow: string,
   /** The list of document fields to return when performing the search. Defaults to all fields (*). */
-  fields: Array<string>;
+  fields: Array<string>,
   /** The list of facets to request when performing the search. Defaults to just 'table'. */
-  facets: Array<string>;
+  facets: Array<string>,
   /** The list of relevancy models to use when performing the search. Defaults to the 'default' model. */
-  relevancyModels: Array<string>;
+  relevancyModels: Array<string>,
   /** The maximum number of facets for FacetFinder to add. Defaults to 0, which means FF is disabled. */
-  facetFinderCount: number;
+  facetFinderCount: number,
   /** An optional filter to apply to all queries. */
-  queryFilter?: string | null;
+  queryFilter?: string | null,
   /**
    * Highlight mode for the results of your query: 'on' enables highlighting
    * using your schema preferences and field expressions, 'off' disables
    * highlighting on the request, only highlighting field expressions specified, and
    * 'all' adds a teaser field expression to all your display fields when not in debug mode.
    */
-  highlightResults: 'on' | 'off' | 'all';
+  highlightResults: 'on' | 'off' | 'all',
   /** The join rollup mode to use. Defaults to 'TREE'. */
-  joinRollupMode: 'TREE' | 'AGGREGATE' | 'SQL';
+  joinRollupMode: 'TREE' | 'AGGREGATE' | 'SQL',
   /** An optional locale to use for the search. */
-  locale?: string | null;
+  locale?: string | null,
   /** The default language to use for querying. Defaults to 'simple' if not specified. */
-  defaultQueryLanguage: 'simple' | 'advanced';
+  defaultQueryLanguage: 'simple' | 'advanced',
 
   /** A field expression to override what is used for the title, defaults to 'title' */
-  title: string;
+  title: string,
   /** A field expression to override what is used for the URI, defaults to 'uri' */
-  uri: string;
+  uri: string,
   /** A field expression to override what is used for the table, defaults to 'table' */
-  table: string;
+  table: string,
   /**
    * A field expression to override what is used for the teaser, defaults to
    * 'SCOPETEASER(text, fragment=true, numFragments=4, fragmentScope=sentence)'
    */
-  teaser: string;
+  teaser: string,
   /**
    * A field expression to override what is used for the text, defaults to
    * 'SCOPETEASER(text, fragment=true, numFragments=1, fragmentSize=2147483647)'
    */
-  text: string;
+  text: string,
   /**
    * A field expression to override what is used for the URI to the preview image,
    * defaults to 'img.uri.preview'
    */
-  previewImageUri: string;
+  previewImageUri: string,
   /** A field expression to override what is used for the UTI to the document’s
    * thumbnail, defaults to 'img.uri.thumbnail' */
-  thumbnailImageUri: string;
+  thumbnailImageUri: string,
   /** A field expression to override what is used for the latitude, defaults to 'latitude' */
-  latitude: string;
+  latitude: string,
   /** A field expression to override what is used for the longitude, defaults to 'longitude' */
-  longitude: string;
+  longitude: string,
   /**
    * A field expression to override what is used for the query to use when asking
    * for similar documents, defaults to 'morelikethisquery' */
-  moreLikeThisQuery: string;
+  moreLikeThisQuery: string,
   /** A field expression to override what is used for the MIME type, defaults to 'mimetype' */
-  mimetype: string;
+  mimetype: string,
   /**
    * A field expression to override what is used for the path to the ingested document,
    * defaults to 'sourcepath'
    */
-  sourcePath: string;
+  sourcePath: string,
   /** If true, include fields added by the query workflow, defaults to true */
   // showWorkflowFields: boolean;
   /** The workflow to use when updating document properties, defaults to 'ingest' */
@@ -132,52 +132,52 @@ type SearcherProps = {
   /** Whether to override the format with the debug format. */
   debug: boolean,
   /** The number of document results to display on each page of the results set */
-  resultsPerPage: number;
+  resultsPerPage: number,
   /**
    * The name of the Business Center profile to use for queries. If set, this will enable Profile level campaigns and promotions.
    */
-  businessCenterProfile: string | null;
+  businessCenterProfile: string | null,
   /**
    * The Searcher contains arbitrary children, including the components that
    * control its properties and display the search results.
    */
-  children: Children;
+  children: Children,
   /**
    * The max resubmits property for enabling features such as And-To-Or resubmission, if desired
    */
-  maxResubmits: number;
+  maxResubmits: number,
 };
 
 type SearcherDefaultProps = {
-  searchEngineType: 'attivio' | 'elastic' | 'solr';
-  customOptions: any;
-  baseUri: string;
-  searchWorkflow: string;
-  fields: Array<string>;
-  facets: Array<string>;
-  relevancyModels: Array<string>;
-  facetFinderCount: number;
-  queryFilter: string | null;
-  highlightResults: 'on' | 'off' | 'all';
-  joinRollupMode: 'TREE' | 'AGGREGATE' | 'SQL';
-  locale: string | null;
-  title: string;
-  uri: string;
-  table: string;
-  teaser: string;
-  text: string;
-  previewImageUri: string;
-  thumbnailImageUri: string;
-  latitude: string;
-  longitude: string;
-  moreLikeThisQuery: string;
-  mimetype: string;
-  sourcePath: string;
-  debug: boolean;
-  resultsPerPage: number;
-  businessCenterProfile: string | null;
-  defaultQueryLanguage: 'simple' | 'advanced';
-  maxResubmits: number;
+  searchEngineType: 'attivio' | 'elastic' | 'solr',
+  customOptions: any,
+  baseUri: string,
+  searchWorkflow: string,
+  fields: Array<string>,
+  facets: Array<string>,
+  relevancyModels: Array<string>,
+  facetFinderCount: number,
+  queryFilter: string | null,
+  highlightResults: 'on' | 'off' | 'all',
+  joinRollupMode: 'TREE' | 'AGGREGATE' | 'SQL',
+  locale: string | null,
+  title: string,
+  uri: string,
+  table: string,
+  teaser: string,
+  text: string,
+  previewImageUri: string,
+  thumbnailImageUri: string,
+  latitude: string,
+  longitude: string,
+  moreLikeThisQuery: string,
+  mimetype: string,
+  sourcePath: string,
+  debug: boolean,
+  resultsPerPage: number,
+  businessCenterProfile: string | null,
+  defaultQueryLanguage: 'simple' | 'advanced',
+  maxResubmits: number,
 };
 
 /*
@@ -192,18 +192,19 @@ type SearcherDefaultProps = {
  *   getDefaultState()
  */
 type SearcherState = {
-  haveSearched: boolean;
-  response?: QueryResponse;
-  error?: string;
-  query: string;
-  queryLanguage: 'advanced' | 'simple';
+  haveSearched: boolean,
+  response?: QueryResponse,
+  error?: string,
+  query: string,
+  queryLanguage: 'advanced' | 'simple',
   sort: Array<string>,
-  relevancyModels: Array<string>;
-  facetFilters: Array<FacetFilter>;
-  geoFilters: Array<string>;
-  resultsPerPage: number;
-  resultsOffset: number;
-  debug: boolean;
+  relevancyModels: Array<string>,
+  facetFilters: Array<FacetFilter>,
+  geoFilters: Array<string>,
+  resultsPerPage: number,
+  resultsOffset: number,
+  debug: boolean,
+  isSearching: boolean,
 };
 
 /**
@@ -301,7 +302,7 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
 
   static childContextTypes = {
     searcher: PropTypes.any,
-  }
+  };
 
   static displayName = 'Searcher';
 
@@ -311,23 +312,27 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
    * Convert an array of facet filters to an array of string representations thereof.
    */
   static serializeFacetFilters(facetFilters: Array<FacetFilter>): Array<string> {
-    return facetFilters.map((facetFilter: FacetFilter): string => {
-      return `${facetFilter.facetName},+${facetFilter.bucketLabel},+${facetFilter.filter}`;
-    });
+    return facetFilters.map(
+      (facetFilter: FacetFilter): string => {
+        return `${facetFilter.facetName},+${facetFilter.bucketLabel},+${facetFilter.filter}`;
+      },
+    );
   }
 
   /**
    * Convert an array of stringified facet filters to an array of actual FacetFilter objects.
    */
   static deserializeFacetFilters(facetFilters: Array<string>): Array<FacetFilter> {
-    return facetFilters.map((facetFilterString: string): FacetFilter => {
-      const parts: Array<string> = facetFilterString.split(',+');
-      const facetFilter = new FacetFilter();
-      facetFilter.facetName = parts[0];
-      facetFilter.bucketLabel = parts[1];
-      facetFilter.filter = parts[2];
-      return facetFilter;
-    });
+    return facetFilters.map(
+      (facetFilterString: string): FacetFilter => {
+        const parts: Array<string> = facetFilterString.split(',+');
+        const facetFilter = new FacetFilter();
+        facetFilter.facetName = parts[0];
+        facetFilter.bucketLabel = parts[1];
+        facetFilter.filter = parts[2];
+        return facetFilter;
+      },
+    );
   }
 
   constructor(props: SearcherProps) {
@@ -391,6 +396,7 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
       resultsPerPage: parseInt(this.props.resultsPerPage, 10),
       resultsOffset: 0,
       debug: this.props.debug,
+      isSearching: false,
     };
   }
 
@@ -548,6 +554,7 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
     if (state.debug !== this.props.debug) {
       basicState.debug = state.debug;
     }
+    basicState.isSearching = this.state.isSearching;
 
     // See if there are any query parameters other than those set by the Searcher. If so, we want to maintain them.
     if (originalQueryString) {
@@ -562,6 +569,7 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
         originalParsed.delete('sort');
         originalParsed.delete('relevancyModels');
         originalParsed.delete('debug');
+        originalParsed.delete('isSearching');
       }
       // Add any leftover fields back in to the basic state
       basicState = Object.assign({}, basicState, originalParsed);
@@ -571,10 +579,10 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
   }
 
   /**
- * Given the query string from the location URL, parse it into the values of a SearcherState
- * object. Values which are missing are set to their default values. Any values in the
- * queryString which don't apply to the SearcherState are ignored.
- */
+   * Given the query string from the location URL, parse it into the values of a SearcherState
+   * object. Values which are missing are set to their default values. Any values in the
+   * queryString which don't apply to the SearcherState are ignored.
+   */
   parseLocationQueryStringToState(queryString: string): SearcherState {
     const parsed = QueryString.parse(queryString);
 
@@ -668,6 +676,11 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
       debug = parsed.debug;
     }
 
+    let isSearching = false;
+    if (Object.prototype.hasOwnProperty.call(parsed, 'isSearching')) {
+      isSearching = parsed.isSearching === 'true';
+    }
+
     const result: SearcherState = {
       query,
       queryLanguage,
@@ -679,6 +692,7 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
       relevancyModels,
       debug,
       haveSearched: this.state.haveSearched, // Make sure we don't change this
+      isSearching,
     };
 
     return result;
@@ -836,18 +850,27 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
    */
   doSearch() {
     const qr = this.getQueryRequest();
-    this.search.search(qr, (response: QueryResponse | null, error: string | null) => {
-      this.updateSearchResults(response, error);
 
-      // potentially do window.scrollTo(0, 0)?
+    const localCallBack = () => {
+      this.search.search(qr, (response: QueryResponse | null, error: string | null) => {
+        this.setState({ isSearching: false }, () => {
+          this.updateSearchResults(response, error);
 
-      // Update the URL if needed.
-      const oldQueryString = this.props.location.query;
-      const updatedQueryString = this.generateLocationQueryStringFromState(this.state, oldQueryString);
-      if (oldQueryString !== updatedQueryString) {
-        this.props.history.push(`?${updatedQueryString}`);
-      }
-    });
+          // potentially do window.scrollTo(0, 0)?
+
+          // Update the URL if needed.
+          const oldQueryString = this.props.location.query;
+          const updatedQueryString = this.generateLocationQueryStringFromState(this.state, oldQueryString);
+          if (oldQueryString !== updatedQueryString) {
+            this.props.history.push(`?${updatedQueryString}`);
+          }
+          this.updateSearchResults(response, error);
+        });
+      });
+    };
+    if (!this.state.isSearching) {
+      this.setState({ isSearching: true }, localCallBack);
+    }
   }
 
   /**
@@ -875,11 +898,14 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
     const callBackWrapper = () => {
       this.updateStateResetAndSearch(this.getDefaultState());
     };
-    this.setState({
-      haveSearched: false,
-      response: undefined,
-      error: undefined,
-    }, callBackWrapper);
+    this.setState(
+      {
+        haveSearched: false,
+        response: undefined,
+        error: undefined,
+      },
+      callBackWrapper,
+    );
   }
 
   /**
@@ -898,7 +924,6 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
       query,
     });
   }
-
 
   /**
    * Add multiple query filters (in AQL) to the query request.
@@ -986,11 +1011,7 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
 
   render() {
     // Nothing special to do here. The children will all look at our state to decide what to render
-    return (
-      <div>
-        {this.props.children}
-      </div>
-    );
+    return <div>{this.props.children}</div>;
   }
 }
 

--- a/src/components/Spinner.js
+++ b/src/components/Spinner.js
@@ -35,7 +35,7 @@ class Spinner extends React.Component<SpinnerDefaultProps, SpinnerProps, void> {
         ''
       );
     return (
-      <div className="attivio-custom-spinner">
+      <div className="attivio-spinner">
         <img src={this.props.spinner} alt="Spinner" width={this.props.spinnerWidth} height={this.props.spinnerHeight} />
         {label}
       </div>

--- a/src/components/Spinner.js
+++ b/src/components/Spinner.js
@@ -1,0 +1,46 @@
+// @flow
+
+import React from 'react';
+import Configurable from './Configurable';
+
+type SpinnerProps = {
+  spinner?: string;
+  spinnerHeight?: string;
+  spinnerWidth?: string;
+  spinnerLabel?: string;
+};
+
+type SpinnerDefaultProps = {
+  spinner?: string;
+  spinnerHeight?: string;
+  spinnerWidth?: string;
+  spinnerLabel?: string;
+};
+
+class Spinner extends React.Component<SpinnerDefaultProps, SpinnerProps, void> {
+  static defaultProps = {
+    spinner: 'img/spinner.gif',
+    spinnerHeight: '50%',
+    spinnerWidth: '50%',
+    spinnerLabel: '',
+  };
+
+  render() {
+    const label = this.props.spinnerLabel ? (
+      <div>
+        <br />
+        <b>{this.props.spinnerLabel}</b>
+      </div>
+    ) : (
+        ''
+      );
+    return (
+      <div className="attivio-custom-spinner">
+        <img src={this.props.spinner} alt="Spinner" width={this.props.spinnerWidth} height={this.props.spinnerHeight} />
+        {label}
+      </div>
+    );
+  }
+}
+
+export default Configurable(Spinner);

--- a/src/index.js
+++ b/src/index.js
@@ -150,6 +150,7 @@ export SimpleSearchResult from './components/SimpleSearchResult';
 export SimpleAutoCompleteInput from './components/SimpleAutoCompleteInput';
 export SmallTabs from './components/SmallTabs';
 export SpellCheckMessage from './components/SpellCheckMessage';
+export Spinner from './components/Spinner';
 export SqlLog from './components/SqlLog';
 export StarRating from './components/StarRating';
 export StringListEditor from './components/StringListEditor';


### PR DESCRIPTION
Adds a new state variable isSearching to the searcher to keep track of when the system is searching. Also adds a new Spinner component that can be shown when a search is being performed.

Below is an example of Spinner being used in SearchUI:
![Spinner](https://user-images.githubusercontent.com/31805650/56383615-446fdf00-61e8-11e9-8b6f-241e96a12cd0.gif)

Spinner is configurable through SearchUI's configuration.properties file. Here is an example:

```
  Spinner: {
	// name of the spinner image with the extension placed in searchui/frontend/src/img folder
	spinner: 'img/spinner2.gif',
	// height for the spinner
	spinnerHeight: '50%',
	// width for the spinner
	spinnerWidth: '50%',
	// text that should be displayed with the spinner
	spinnerLabel: 'Loading Results...',
  },```
