### PR TITLE
issue-108: Add saved search feature

### DIFF
--- a/src/api/Search.js
+++ b/src/api/Search.js
@@ -178,4 +178,102 @@ export default class Search {
       });
     });
   }
+
+  updateSavedSearches(jsonRequest: JSON, callback: () => void): Promise<any> {
+    return new Promise((resolve, reject) => {
+      // Get session
+      const connectUri = `${this.baseUri}/rest/ingestApi/connect`;
+      fetch(connectUri, { credentials: 'include' })
+        .then((connectResult) => {
+          connectResult
+            .json()
+            .then((json) => {
+              const sessionId = json;
+              const updateUri = `${this.baseUri}/rest/ingestApi/feedDocuments/${sessionId}`;
+
+              const headers = new Headers({
+                Accept: 'application/json',
+                'Content-Type': 'application/json',
+              });
+
+              const body = JSON.stringify(jsonRequest);
+              const params = {
+                method: 'POST',
+                headers,
+                body,
+                credentials: 'include',
+              };
+
+              const updateFetchRequest = new Request(updateUri, params);
+              fetch(updateFetchRequest)
+                .then((updateResult: Response) => {
+                  if (updateResult.ok) {
+                    // Now need to refresh the update
+                    const refreshUri = `${this.baseUri}/rest/ingestApi/refresh/${sessionId}`;
+                    fetch(refreshUri, { credentials: 'include' })
+                      .then((refreshResult: Response) => {
+                        if (refreshResult.ok) {
+                          // Now need to close the session
+                          const disconnectUri = `${this.baseUri}/rest/ingestApi/disconnect/${sessionId}`;
+                          fetch(disconnectUri, { credentials: 'include' })
+                            .then((disconnectResult: Response) => {
+                              if (disconnectResult.ok) {
+                                callback();
+                                resolve();
+                              } else {
+                                // The request came back other than a 200-type response code
+                                disconnectResult
+                                  .text()
+                                  .then((msg) => {
+                                    reject(new Error(`Error disconnecting from the ingest API: ${msg}`));
+                                  })
+                                  .catch(() => {
+                                    reject(new Error(`Error disconnecting from the ingest API: ${disconnectResult.statusText}`));
+                                  });
+                              }
+                            })
+                            .catch((error) => {
+                              reject(new Error(`Failed to disconnect from the ingest API: ${error}`));
+                            });
+                        } else {
+                          // The request came back other than a 200-type response code
+                          refreshResult
+                            .text()
+                            .then((msg) => {
+                              reject(new Error(`Failed to refresh the update: ${msg}`));
+                            })
+                            .catch(() => {
+                              reject(new Error(`Failed to refresh the update: ${refreshResult.statusText}`));
+                            });
+                        }
+                      })
+                      .catch((error) => {
+                        reject(new Error(`Failed to refresh the update: ${error}`));
+                      });
+                  } else {
+                    // The request came back other than a 200-type response code
+                    updateResult
+                      .text()
+                      .then((msg) => {
+                        reject(new Error(`Failed to update the field: ${msg}`));
+                      })
+                      .catch((error) => {
+                        reject(new Error(`Failed to update the field: ${error}`));
+                      });
+                  }
+                })
+                .catch((error: any) => {
+                  // Catch network-type errors from the updating fetch() call
+                  reject(new Error(`Failed to update the field: ${error}`));
+                });
+            })
+            .catch((error) => {
+              reject(new Error(`Failed to connect to the ingest API: ${error}`));
+            });
+        })
+        .catch((error) => {
+          reject(new Error(`Failed to connect to the ingest API: ${error}`));
+        });
+    });
+  }
 }

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -3,17 +3,27 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 
-import Dropdown from 'react-bootstrap/lib/Dropdown';
-import Glyphicon from 'react-bootstrap/lib/Glyphicon';
-import MenuItem from 'react-bootstrap/lib/MenuItem';
+import {
+  Dropdown,
+  Glyphicon,
+  MenuItem,
+  Button,
+  Modal,
+  Row,
+  Col,
+} from 'react-bootstrap';
 
 import Configurable from './Configurable';
 import AutoCompleteInput from './AutoCompleteInput';
+import AuthUtils from '../util/AuthUtils';
+import SimpleQueryRequest from '../api/SimpleQueryRequest';
+import QueryResponse from '../api/QueryResponse';
 
 declare var webkitSpeechRecognition: any; // Prevent complaints about this not existing
 
 type SearchBarProps = {
   history: PropTypes.object.isRequired;
+  location: PropTypes.object.isRequired;
   /** If set, this will be styled to live inside a Masthead component. */
   inMasthead: boolean;
   /**
@@ -54,6 +64,14 @@ type SearchBarProps = {
   buttonLabel: string;
   /** If set, this is the route to navigate to upon executing a search. By default, no navigation will occur when searching. */
   route: string | null;
+  /** If set, the save search option is displayed next to the SearchBar, false by default */
+  allowSavedSearch: boolean;
+  /** Optional, specifies the workflow that should be used for querying the index which stores saved searches */
+  savedSearchWorkflow?: string;
+  /** Optional, specifies the table name assigned to the docs for saved searches, defaults to 'savedSearches' */
+  savedSearchTable: string;
+  /** Specifies the zone name for the zone that stores saved searches, defaults to 'savedSearches' */
+  savedSearchZone: string;
 };
 
 type SearchBarDefaultProps = {
@@ -66,11 +84,19 @@ type SearchBarDefaultProps = {
   autoCompleteUri: string | null;
   route: string | null;
   baseUri: string;
+  allowSavedSearch: boolean;
+  savedSearchTable: string,
+  savedSearchZone: string;
 };
 
 type SearchBarState = {
   recognizing: boolean;
   suggestions: Array<string>;
+  response?: QueryResponse;
+  error?: string;
+  showSaveSearchModal: boolean;
+  savedSearchTitle: string;
+  savedSearchList: Array<any>;
 };
 
 /**
@@ -88,6 +114,10 @@ class SearchBar extends React.Component<SearchBarDefaultProps, SearchBarProps, S
     autoCompleteUri: null,
     route: null,
     baseUri: '',
+    allowSavedSearch: false,
+    savedSearchWorkflow: '',
+    savedSearchTable: 'savedSearches',
+    savedSearchZone: 'savedSearches',
   };
 
   static contextTypes = {
@@ -104,7 +134,11 @@ class SearchBar extends React.Component<SearchBarDefaultProps, SearchBarProps, S
       query: '',
       recognizing: false,
       suggestions: [],
-
+      response: undefined,
+      error: undefined,
+      showSaveSearchModal: false,
+      savedSearchTitle: '',
+      savedSearchList: [],
     };
     (this: any).doKeyPress = this.doKeyPress.bind(this);
     (this: any).doSearch = this.doSearch.bind(this);
@@ -112,12 +146,23 @@ class SearchBar extends React.Component<SearchBarDefaultProps, SearchBarProps, S
     (this: any).queryChanged = this.queryChanged.bind(this);
     (this: any).updateQuery = this.updateQuery.bind(this);
     (this: any).languageChanged = this.languageChanged.bind(this);
+    (this: any).applySavedSearch = this.applySavedSearch.bind(this);
+    (this: any).showSaveSearchModal = this.showSaveSearchModal.bind(this);
+    (this: any).hideSaveSearchModal = this.hideSaveSearchModal.bind(this);
+    (this: any).getSavedSearches = this.getSavedSearches.bind(this);
+    (this: any).searchTitleEntered = this.searchTitleEntered.bind(this);
     if (this.props.allowVoice && !('webkitSpeechRecognition' in window)) {
       console.log('Requested speech recognition but the browser doesn’t support it'); // eslint-disable-line no-console
     }
   }
 
   state: SearchBarState;
+
+  componentWillMount() {
+    if (this.props.allowSavedSearch) {
+      this.getSavedSearches();
+    }
+  }
 
   getSuggestionList() {
     if (!this.state.suggestions || this.state.suggestions.length === 0) {
@@ -131,6 +176,86 @@ class SearchBar extends React.Component<SearchBarDefaultProps, SearchBarProps, S
         {contents}
       </ul>
     );
+  }
+
+  // queries the index for the saved searches and sets the response to state
+  getSavedSearches() {
+    const username = AuthUtils.getLoggedInUserId();
+    const searcher = this.context.searcher;
+    const { savedSearchWorkflow, savedSearchTable, savedSearchZone } = this.props;
+    if (searcher) {
+      const qr = new SimpleQueryRequest();
+      qr.query = `AND(table:${savedSearchTable}, username_s:"${username}")`;
+      qr.facets = [];
+      qr.restParams.set('zones', [`${savedSearchZone}`]);
+      if (savedSearchWorkflow) {
+        qr.workflow = savedSearchWorkflow;
+      }
+      qr.queryLanguage = 'advanced';
+      searcher.doCustomSearch(qr, (response: QueryResponse | null, error: string | null) => {
+        if (response) {
+          this.setState(
+            {
+              response,
+            },
+            this.populateSavedSearches,
+          );
+        } else if (error) {
+          this.setState({ error });
+        }
+      });
+    }
+  }
+
+  // applies the saved search which includes a query and facet filters
+  applySavedSearch(query: string) {
+    const { location } = this.props;
+    this.props.history.push({
+      pathname: location.pathname,
+      search: query,
+    });
+  }
+
+  // populates the saved searches in the saved searches drop down
+  populateSavedSearches() {
+    const response = this.state.response;
+    if (response) {
+      const menuItemList = [];
+      response.documents.forEach((doc) => {
+        const savedSearch = {};
+        const htmlString = doc.getFirstValue('title');
+        savedSearch.id = doc.getFirstValue('.id');
+        savedSearch.title = htmlString.replace(/<[^>]+>/g, '');
+        savedSearch.query = doc.getFirstValue('query_s');
+        savedSearch.queryString = doc.getFirstValue('query_string_s');
+        let savedSearchTitle = savedSearch.title;
+        savedSearchTitle = savedSearchTitle.length > 15 ? `${savedSearchTitle.substring(0, 15)}...` : savedSearchTitle;
+        menuItemList.push(
+          <MenuItem key={savedSearch.id}>
+            <span // eslint-disable-line
+              onClick={() => {
+                this.applySavedSearch(savedSearch.query);
+              }}
+              title={savedSearch.title}
+            >
+              {savedSearchTitle}
+            </span>
+            <span // eslint-disable-line
+              onClick={() => {
+                this.deleteThisSearch(savedSearch.id);
+              }}
+              style={{
+                float: 'right',
+                fontWeight: 'bold',
+              }}
+            >
+              &times;
+            </span>
+          </MenuItem>,
+        );
+      });
+      this.setState({ savedSearchList: menuItemList });
+    }
   }
 
   submitButton: ?HTMLButtonElement;
@@ -196,7 +321,16 @@ class SearchBar extends React.Component<SearchBarDefaultProps, SearchBarProps, S
     }
   }
 
+  searchTitleEntered(e: Event) {
+    if (e.target instanceof HTMLInputElement) {
+      this.setState({
+        savedSearchTitle: e.target.value,
+      });
+    }
+  }
+
   advancedMenuItem: ?HTMLSpanElement;
+
   simpleMenuItem: ?HTMLSpanElement;
 
   route() {
@@ -223,6 +357,44 @@ class SearchBar extends React.Component<SearchBarDefaultProps, SearchBarProps, S
     }
   }
 
+  // saves the current search from the url and feed it to a separate index zone
+  saveThisSearch(searcherState) {
+    const searcher = this.context.searcher;
+    const { savedSearchZone, savedSearchTable } = this.props;
+    const currentSearch = searcher.generateLocationQueryStringFromState(searcherState);
+    const username = AuthUtils.getLoggedInUserId();
+    const loggedDateTime = new Date().toISOString();
+    const id = username.concat(loggedDateTime);
+    const title = this.state.savedSearchTitle;
+    const queryString = searcher.state.query;
+
+    const jsonDoc = '{ "fields" : { "title" : '
+      + `[ "${title}" ], "query_s" : [ "${currentSearch}" ], "query_string_s" : [ "${queryString}" ], `
+      + `"username_s" : [ "${username}" ], "date" : [ "${loggedDateTime}" ], "table" : [ "${savedSearchTable}" ] }, `
+      + `"id" : "${id}", "zone" : "${savedSearchZone}" }`;
+    searcher.search.updateSavedSearches(JSON.parse(jsonDoc), this.getSavedSearches);
+    this.hideSaveSearchModal();
+  }
+
+  deleteThisSearch(id: string) {
+    const { savedSearchZone } = this.props;
+    const jsonDoc = `{ "id" : "${id}", "zone" : "${savedSearchZone}", "mode" : "DELETE" }`;
+    this.context.searcher.search.updateSavedSearches(JSON.parse(jsonDoc), this.getSavedSearches);
+  }
+
+  // hides the modal
+  hideSaveSearchModal() {
+    this.setState({ showSaveSearchModal: false });
+  }
+
+  // sets the query from searcher as the search title and shows the modal
+  showSaveSearchModal() {
+    this.setState({
+      savedSearchTitle: this.context.searcher.state.query,
+      showSaveSearchModal: true,
+    });
+  }
+
   doKeyPress(e: Event) {
     // If the user presses enter, do the search
     if (e.target instanceof HTMLInputElement) {
@@ -240,6 +412,7 @@ class SearchBar extends React.Component<SearchBarDefaultProps, SearchBarProps, S
     }
 
     const containerClass = this.props.inMasthead ? 'attivio-globalmast-search-container' : '';
+    const subContainerClass = this.props.allowSavedSearch ? 'attivio-globalmast-search-saved-search' : 'attivio-globalmast-search';
     const inputClass = this.props.inMasthead ? 'form-control attivio-globalmast-search-input' : 'form-control';
 
     let query = '';
@@ -328,8 +501,8 @@ class SearchBar extends React.Component<SearchBarDefaultProps, SearchBarProps, S
     }
 
     const suggestionList = this.getSuggestionList();
-    const inputComponent = this.props.autoCompleteUri ?
-      (
+    const inputComponent = this.props.autoCompleteUri
+      ? (
         <AutoCompleteInput
           uri={`${this.props.baseUri}${this.props.autoCompleteUri}`}
           updateValue={this.updateQuery}
@@ -348,9 +521,127 @@ class SearchBar extends React.Component<SearchBarDefaultProps, SearchBarProps, S
         />
       );
 
+    const saveQueryHeader = (
+      <MenuItem
+        key="saveQueryHeader"
+        onSelect={() => {
+          this.showSaveSearchModal();
+        }}
+        id="saveQueryHeader"
+      >
+        <span
+          style={{
+            fontSize: '14px',
+            color: '#003c7e',
+          }}
+        >
+          <b> SAVE SEARCH </b>
+        </span>
+      </MenuItem>
+    );
+
+    const savedQueryDivider = (
+      <div
+        id="recentlySavedSearchesLabel"
+        style={{
+          width: '100%',
+          textAlign: 'center',
+          backgroundColor: '#dff0f9',
+          color: '#5d7c89',
+          cursor: 'default',
+        }}
+      >
+        <b>Recently saved searches:</b>
+      </div>
+    );
+
+    const savedQueryList = this.state.savedSearchList.length > 0 ? (
+      this.state.savedSearchList
+    ) : (
+      <MenuItem key="noSavedSearches">
+        <span
+          style={{
+            color: '#5d7c89',
+            cursor: 'default',
+          }}
+        >
+          No Saved Searches
+        </span>
+      </MenuItem>
+    );
+
+    const saveQuery = this.props.allowSavedSearch ? (
+      <Dropdown id="saveQueryDropDown" className="" componentClass="div" style={{ display: 'inline-block' }}>
+        <Dropdown.Toggle
+          noCaret
+          useAnchor
+          className="attivio-smalltoolbar-btn"
+          bsClass="attivio-smalltoolbar-btn"
+          title="Save This Search"
+          style={{
+            position: 'relative',
+            top: '2px',
+            left: '-1px',
+            color: '#fff',
+            border: 'none',
+            background: 'transparent',
+          }}
+        >
+          <Glyphicon glyph="heart-empty" style={{ color: 'white', fontSize: '1.1em' }} />
+          <span className="attivio-globalmast-icon attivio-icon-arrow-down-blue" />
+        </Dropdown.Toggle>
+        <Dropdown.Menu>
+          {saveQueryHeader}
+          <hr style={{ marginTop: '2px', marginBottom: '2px', color: '#003c7e' }} />
+          {savedQueryDivider}
+          <hr style={{ marginTop: '2px', marginBottom: '2px', color: '#003c7e' }} />
+          {savedQueryList}
+        </Dropdown.Menu>
+      </Dropdown>
+    ) : (
+      ''
+    );
+
+    const saveSearchModal = this.props.allowSavedSearch ? (
+      <Modal show={this.state.showSaveSearchModal} onHide={this.hideSaveSearchModal}>
+        <Modal.Header closeButton>
+          <Modal.Title>Save Current Search</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Row>
+            <Col xs={12} sm={6} md={4} lg={4}>
+              <b> Name for this Search : </b>
+            </Col>
+            <Col xs={12} sm={6} md={8} lg={8}>
+              <input
+                type="text"
+                onChange={this.searchTitleEntered}
+                defaultValue={`${this.context.searcher.state.query}`}
+                style={{ width: '100%' }}
+              />
+            </Col>
+          </Row>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button onClick={this.hideSaveSearchModal}>
+            Close
+          </Button>
+          <Button
+            onClick={() => {
+              this.saveThisSearch(this.context.searcher.state);
+            }}
+          >
+            Save Search
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    ) : (
+      ''
+    );
+
     return (
       <div className={containerClass}>
-        <div className="attivio-globalmast-search" role="search">
+        <div className={subContainerClass} role="search">
           <div className="form-group">
             {inputComponent}
             {showMicrophone ? (
@@ -370,6 +661,8 @@ class SearchBar extends React.Component<SearchBarDefaultProps, SearchBarProps, S
           {suggestionList}
         </div>
         {languageControl}
+        {saveQuery}
+        {saveSearchModal}
       </div>
     );
   }


### PR DESCRIPTION
# Save searches

Save search feature allows you to save your search (including any filters that are applied) which can later be revisited by clicking on the saved search title. This feature is disabled by default.


## How to enable save search
You can turn on the save search option by passing in an additional prop to SearchBar component, this prop is called _allowSavedSearch_. For example: 
```
<SearchBar allowSavedSearch />
```
This would show a heart icon with a drop down next to the Search Bar, which means the UI component for saved search is enabled.
> **Note:** In order to make this feature work, we need to create a new zone to store the saved searches. This feature will **NOT** work if you haven't configured and specified a new zone for saved searches.

## Configuring a new zone to store the saved searches
*Follow these steps to configure a new zone for storing the saved searches:*

 1. Zones are configured via the [Index Feature](https://answers.attivio.com/display/extranet52/Configure+the+Index), in **[project-dir]\conf\features\core\Index.index.xml**.  It should look similar to:
	 ```
	 <?xml version="1.0" encoding="UTF-8"?>

	<ff:features xmlns:ff="http://www.attivio.com/configuration/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:fbase="http://www.attivio.com/configuration/features/base" xmlns:f="http://www.attivio.com/configuration/features/core" xsi:schemaLocation="http://www.attivio.com/configuration/config http://www.attivio.com/configuration/config.xsd http://www.attivio.com/configuration/features/base http://www.attivio.com/configuration/features/baseFeatures.xsd http://www.attivio.com/configuration/features/core http://www.attivio.com/configuration/features/coreFeatures.xsd">
	  <f:index enabled="true" name="index" profile="true">
	    <f:partitionSet size="1"/>
	    <f:writer logCommits="true" nodeset="ingestion" search="true"/>
	  </f:index>
	</ff:features>
	```

 2. Edit this file to add in a new index zone. For example, we're creating a new index zone called *testZone* in the example below:
	 ```
	 <?xml version="1.0" encoding="UTF-8"?>

	<ff:features xmlns:ff="http://www.attivio.com/configuration/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:fbase="http://www.attivio.com/configuration/features/base" xmlns:f="http://www.attivio.com/configuration/features/core" xsi:schemaLocation="http://www.attivio.com/configuration/config http://www.attivio.com/configuration/config.xsd http://www.attivio.com/configuration/features/base http://www.attivio.com/configuration/features/baseFeatures.xsd http://www.attivio.com/configuration/features/core http://www.attivio.com/configuration/features/coreFeatures.xsd">
		<f:index enabled="true" name="index" profile="true">
			<f:writer defaultZoneName="default" logCommits="true" nodeset="ingestion" search="true">
				<f:zone name="default" />
				<f:zone name="testZone" />
			</f:writer>
		</f:index>
	</ff:features>
	```
> If you don't configure any zones, there is always one zone named _default_. However, if you configure zones, you must explicitly configure the default zone in addition to the other zone. Additionally, you can also set up separate search workflows for these zones so you don't get the results from your *testZone* as a part of the search results.

3. Configure the save search in SearchUI's configuration.properties file. You can specify the name of the new index zone for saved searches, the table name for all the documents for saved searches and the search workflow to be used for querying the mentioned zone. Below is an example with default values:
	```
	SearchBar: {
		// configures the search workflow used for saved searches
		savedSearchWorkflow: 'searchSavedSearches',
		// configures the table name for saved searches
		savedSearchTable: 'savedSearches',
		// specifies the index zone for saved searches
		savedSearchZone: 'savedSearches',
	}
	```

## How to use saved searches
After you enable and configure saved searches, you should have this component right next to the search bar:
![SavedSearch](https://user-images.githubusercontent.com/31805650/56602139-cdad5a00-65ca-11e9-9ee8-0744cc3de6cc.gif)

### Saving a search
You can save searches by clicking on the first option in the drop-down menu 'SAVE SEARCH'. It will open up a modal that asks for the name for this search. 
![Save a search](https://user-images.githubusercontent.com/31805650/56602446-7956aa00-65cb-11e9-975b-e5f2d1ee4ebc.gif)
> If you don't enter a name, the search term is used as the name.

Click on save search button to save the search.


### Revisiting a search
You can revisit a search by clicking on the search title in the drop-down for saved search.
![Revisit a search](https://user-images.githubusercontent.com/31805650/56602470-8378a880-65cb-11e9-8e25-d04818424108.gif)


### Deleting a saved search
You can also delete a saved search, there's a **x** next to every saved search in the drop-down. Simply click on the **x** to delete a saved search.
![Delete a search](https://user-images.githubusercontent.com/31805650/56602482-8a072000-65cb-11e9-9821-7852ce27dfcb.gif)
> Note that the drop down only shows the 10 most recent saved searches.