### PR TITLE
Updating Utils to handle midnight time issue

### DIFF
--- a/src/components/DocumentEntityList.js
+++ b/src/components/DocumentEntityList.js
@@ -38,7 +38,7 @@ export default class DocumentEntityList extends React.Component<void, DocumentEn
       dataPairs = dataPairs.filter((dataPair: DataPairInfo) => {
         return dataPair.type !== FieldNames.DATE;
       });
-      const dateString = DateUtils.formatDateString(date, DateFormat.LONG_DATE);
+      const dateString = DateUtils.formatDateStringToUTC(date, DateFormat.LONG_DATE); // Updating dateFormat for 
       // We always want the date to come first
       dataPairs.unshift(new DataPairInfo('Date', dateString));
     }

--- a/src/components/DocumentEntityList.js
+++ b/src/components/DocumentEntityList.js
@@ -38,7 +38,8 @@ export default class DocumentEntityList extends React.Component<void, DocumentEn
       dataPairs = dataPairs.filter((dataPair: DataPairInfo) => {
         return dataPair.type !== FieldNames.DATE;
       });
-      const dateString = DateUtils.formatDateStringToUTC(date, DateFormat.LONG_DATE); // Updating dateFormat for 
+      // Updating dateFormat for
+      const dateString = DateUtils.formatDateStringToUTC(date, DateFormat.LONG_DATE); 
       // We always want the date to come first
       dataPairs.unshift(new DataPairInfo('Date', dateString));
     }

--- a/src/util/DateUtils.js
+++ b/src/util/DateUtils.js
@@ -81,6 +81,37 @@ export default class DateUtils {
   }
 
   /**
+   * Given a string, return a Date object created by parsing it.
+   */
+  static stringToUTCDate(dateString: string): Date {
+    return moment.utc(dateString);
+  }
+
+   /**
+   * Given a string, date format and locale, return a formatted date in the specified locale using
+   * the format specified.
+   * @param dateString date as string
+   * @param format given format for coversion
+   * @param locale given locale
+   * @return a formatted date in the specified locale using
+   * the format specified.
+   * @author Shruti Shetty
+   * @date 2nd May 2019
+   */
+
+  static formatDateStringToUTC(
+    dateString: string | null,
+    format: DateFormat,
+    locale: string = "en"
+  ): string {
+    if (dateString) {
+      const date = DateUtils.stringToUTCDate(dateString);
+      return DateUtils.formatDate(date, format, locale);
+    }
+    return "";
+  }
+
+  /**
  * Format the date range presented for display in places such as
  * tooltips on TimeSeries charts. Based on the difference in the
  * start and end times, it will display either a single value or

--- a/src/util/DateUtils.js
+++ b/src/util/DateUtils.js
@@ -102,13 +102,13 @@ export default class DateUtils {
   static formatDateStringToUTC(
     dateString: string | null,
     format: DateFormat,
-    locale: string = "en"
+    locale: string = 'en',
   ): string {
     if (dateString) {
       const date = DateUtils.stringToUTCDate(dateString);
       return DateUtils.formatDate(date, format, locale);
     }
-    return "";
+    return '';
   }
 
   /**

--- a/src/util/DateUtils.js
+++ b/src/util/DateUtils.js
@@ -96,7 +96,6 @@ export default class DateUtils {
    * @return a formatted date in the specified locale using
    * the format specified.
    * @author Shruti Shetty
-   * @date 2nd May 2019
    */
 
   static formatDateStringToUTC(


### PR DESCRIPTION
Updating DateUtils and DocumentEntityList where when dates are converted to desired format with midnight date, current format converts it to a previous day on UI. Issue raised against JIRA ticket NYL-352