### PR TITLE
bug/PLAT-42958: Fix Table update issue

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -58,3 +58,11 @@ Fixes issue in `<Table />` where `onSelect` was passed a `null` value for `activ
 ## Version 0.1.5
 
 Fixes typo in `<Table />` where `selectedRowIndices` was updated in place of `selectedIndices`.
+
+## Version 0.1.6
+
+Adds a new component called `<SwipeViews />` which uses the `react-swipe` library to show multiple views that you can navigated through by using the left and right buttons.
+
+## Version 0.1.7
+
+Fixes issue in `<Table />` where selected row values became stale after data changed and selection did not.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@attivio/suit",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Attivio SUIT, the Search UI Toolkit, is a library for creating search clients for searching the Attivio platform.",
   "keywords": [
     "Attivio",

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -276,14 +276,17 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
         activeRowIndex,
       });
     } else if (!isEqual(newProps.rows, this.props.rows)) {
-      // Selection hasn't changed, but other row data has update row data
+      // Selection hasn't changed, but other row data has, update row data
       const sortedRows = newProps.rows && newProps.rows.length > 0
       ? newProps.rows.map((row, tableRowIndex) => {
         return { ...row, tableRowIndex };
       })
       : [];
-      this.setState({
-        sortedRows,
+      this.setState({ sortedRows }, () => {
+        const activeRow = sortedRows[this.state.activeRowIndex];
+        if (newProps.onSelect) {
+          newProps.onSelect(this.state.sortedRows, activeRow);
+        }
       });
     }
   }


### PR DESCRIPTION
Addresses [PLAT-42958](https://jira.attivio.com/browse/PLAT-42958).

Added additional `onSelect` call. While the selection hasn't changed, the selection data may have. This fixes the stale data issue in the detail pane on connector admin.