### PR TITLE
bug/PLAT-43828 changes made to display only selected connectors onload & on connector creation instead of all connectors

### DIFF
--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -283,9 +283,12 @@ export default class Table extends React.Component<TableDefaultProps, TableProps
       })
       : [];
       this.setState({ sortedRows }, () => {
-        const activeRow = sortedRows[this.state.activeRowIndex];
+        const activeRow = this.state.activeRowIndex !== null && newProps.noEmptySelection
+        ? sortedRows[this.state.activeRowIndex] : null;
+        const selectedRows = this.state.activeRowIndex !== null && newProps.noEmptySelection
+        ? [sortedRows[this.state.activeRowIndex]] : [];
         if (newProps.onSelect) {
-          newProps.onSelect(this.state.sortedRows, activeRow);
+          newProps.onSelect(selectedRows, activeRow);
         }
       });
     }


### PR DESCRIPTION
bug/PLAT-43828 On ConnectorAdmin page load, if Stop selected is clicked from Selected Items menu, all Connectors are prompted
Reload / Open connector admin in a new tab. Click on "Selected Items" gear icon, and select any action. The Confirmation box shows all the connectors, even though by default, only the first connector is selected.

Changes made to ensure on page load & on creation on new connector if user does not select any connector, the first connector is only selected and not all the connectors. 

![image](https://user-images.githubusercontent.com/46693961/59714992-e314be00-91e0-11e9-994a-6ec317a3df69.png)
