### PR TITLE
bug/PLAT-41437 changes to ensure no action is performed on double click of selected node

### DIFF
--- a/src/components/KnowledgeGraphPanel.js
+++ b/src/components/KnowledgeGraphPanel.js
@@ -129,10 +129,18 @@ export default class KnowledgeGraphPanel extends React.Component<KnowledgeGraphP
           const node = this.state.nodes.find((n) => {
             return n.id === nodeId;
           });
-          if (node && node.docId) {
-            this.props.navigateToDoc(node.docId);
-          } else if (node) {
-            this.props.navigateToEntity(node.group, node.label);
+          /**
+           * we do not want any action to be performed
+           * on the double click of the selected node
+           * i.e. the zeroth node.
+           * */
+          if (nodeId !== 0) {
+            // document id is null for the selected node
+            if (node && node.docId) {
+              this.props.navigateToDoc(node.docId);
+            } else if (node) {
+              this.props.navigateToEntity(node.group, node.label);
+            }
           }
         }
       }

--- a/src/components/KnowledgeGraphPanel.js
+++ b/src/components/KnowledgeGraphPanel.js
@@ -126,15 +126,15 @@ export default class KnowledgeGraphPanel extends React.Component<KnowledgeGraphP
         const nodes: Array<number> = event.nodes;
         if (nodes.length > 0) {
           const nodeId = nodes[0];
-          const node = this.state.nodes.find((n) => {
-            return n.id === nodeId;
-          });
           /**
            * we do not want any action to be performed
            * on the double click of the selected node
            * i.e. the zeroth node.
            * */
           if (nodeId !== 0) {
+            const node = this.state.nodes.find((n) => {
+              return n.id === nodeId;
+            });
             // document id is null for the selected node
             if (node && node.docId) {
               this.props.navigateToDoc(node.docId);


### PR DESCRIPTION
PLAT-41437 Clicking on main document in knowledge graph of 360 view gives an exception

Changes to ensure double click of selected node (patient 0) does not lead to any action.

