### PR TITLE
bug/PLAT-41442 unifying behaviour of search on the click of Enter & Go and having the facet filter reset on new query

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -101,3 +101,6 @@ Fixes an issue where clicking on the main document from within the knowledge gra
 
 Adds machinery to optionally provide signal data to <AutoCompleteInput /> whenever user clicks/selects an entry.
 
+## Unpublished Changes
+
+Fixes an issue where on the click of Go the filters of the old query were not being cleared. Unified the behavior on the click of Go & Enter to reset and search on new query being searched and on the same query being searched again no reset of filters is performed.

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -219,8 +219,12 @@ class SearchBar extends React.Component<SearchBarDefaultProps, SearchBarProps, S
     }
     if (searcher) {
       if (doSearch) {
-        searcher.setQueryAndSearch(newQuery);
-        this.route();
+        if (!searcher.state.haveSearched) {
+          searcher.setQueryAndSearch(newQuery);
+          this.route();
+        } else {
+          searcher.doSearch();
+        }
       } else {
         searcher.updateQuery(newQuery);
       }
@@ -254,7 +258,11 @@ class SearchBar extends React.Component<SearchBarDefaultProps, SearchBarProps, S
     const searcher = this.context.searcher;
     if (this.props.route && searcher) {
       this.route();
-    } else {
+    } else if (searcher.state.query && !searcher.state.haveSearched) {
+      // a new query is being searched
+      searcher.setQueryAndSearch(searcher.state.query);
+    } else if (searcher.state.query && searcher.state.haveSearched) {
+      // an old query is being searched
       searcher.doSearch();
     }
     if (this.submitButton) {
@@ -284,6 +292,7 @@ class SearchBar extends React.Component<SearchBarDefaultProps, SearchBarProps, S
     let query = '';
     let language = 'simple';
     const searcher = this.context.searcher;
+
     if (searcher) {
       query = searcher.state.query;
       language = searcher.state.queryLanguage;

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -220,9 +220,12 @@ class SearchBar extends React.Component<SearchBarDefaultProps, SearchBarProps, S
     if (searcher) {
       if (doSearch) {
         if (!searcher.state.haveSearched) {
+          // on click of Enter, if a new query is being searched
+          // reset filters & display results
           searcher.setQueryAndSearch(newQuery);
           this.route();
         } else {
+          // do not reset only search
           searcher.doSearch();
         }
       } else {
@@ -259,10 +262,11 @@ class SearchBar extends React.Component<SearchBarDefaultProps, SearchBarProps, S
     if (this.props.route && searcher) {
       this.route();
     } else if (searcher.state.query && !searcher.state.haveSearched) {
-      // a new query is being searched
+      // on click of Go, if a new query is being searched
+      // reset filters & display results
       searcher.setQueryAndSearch(searcher.state.query);
     } else if (searcher.state.query && searcher.state.haveSearched) {
-      // an old query is being searched
+      // do not reset only search
       searcher.doSearch();
     }
     if (this.submitButton) {

--- a/src/components/Searcher.js
+++ b/src/components/Searcher.js
@@ -488,6 +488,7 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
       error: undefined,
       response: undefined,
       facetFilters: [],
+      geoFilters: [],
       query,
     });
   }
@@ -895,6 +896,7 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
       response: undefined,
       queryLanguage: advanced ? 'advanced' : 'simple',
       facetFilters: [],
+      geoFilters: [],
       query,
     });
   }


### PR DESCRIPTION
PLAT-41442 Facet Filters Not removed when clicked on 'Go' after query is entered

On the click of Go/Enter, check is performed to see if search for that particular query has been carried out.
If yes, hard reset is avoided and only search is performed.
If no, means it is a new search and thus old filters are removed, hard reset and search is performed.

In each case search i.e. the searcher.doSearch is called as it can happen that some ingestion is being done and a click of Go/Enter for the same term can fetch in more results.

Can add more comments if more clarity is needed in code.