### PR TITLE
bug/PLAT-44229 : Ensure pointers in GeoMaps point to the location correctly

### DIFF
--- a/src/components/MapFacetContents.js
+++ b/src/components/MapFacetContents.js
@@ -218,11 +218,11 @@ class MapFacetContents extends React.Component<MapFacetContentsDefaultProps, Map
         // Keep track of the boundaries of the coordinates
         return (
           <Marker
-            coordinates={[longitude || 0, latitude || 0]}
+            coordinates={[longitude, latitude]}
             onClick={() => {
               this.props.addFacetFilter(bucket);
             }}
-            key={`${longitude || 0},${latitude || 0}`}
+            key={`${longitude},${latitude}`}
             style={{ cursor: 'pointer' }}
           >
             <Glyphicon glyph="map-marker" style={{ fontSize: '18px', color: '#2a689c' }} />

--- a/src/components/MapFacetContents.js
+++ b/src/components/MapFacetContents.js
@@ -200,15 +200,20 @@ class MapFacetContents extends React.Component<MapFacetContentsDefaultProps, Map
 
       const points = this.props.buckets.map((bucket) => {
         const value = bucket.value; // JSON.parse(bucket.value);
-        let longitude = 0;
-        let latitude = 0;
+        let longitude = NaN;
+        let latitude = NaN;
         if (typeof value === 'string') {
           const valueArr = value.split(',');
-          longitude = valueArr[0];
-          latitude = valueArr[1];
+          if (valueArr.length === 2) {
+            longitude = Number.parseFloat(valueArr[0]);
+            latitude = Number.parseFloat(valueArr[1]);
+          }
         } else {
           longitude = value.longitude;
           latitude = value.latitude;
+        }
+        if (isNaN(longitude) || isNaN(latitude)) {
+          return null;
         }
         // Keep track of the boundaries of the coordinates
         return (

--- a/src/components/MapFacetContents.js
+++ b/src/components/MapFacetContents.js
@@ -199,7 +199,7 @@ class MapFacetContents extends React.Component<MapFacetContentsDefaultProps, Map
       });
 
       const points = this.props.buckets.map((bucket) => {
-        const value = bucket.value; // JSON.parse(bucket.value);
+        const value = bucket.value;
         let longitude = NaN;
         let latitude = NaN;
         if (typeof value === 'string') {
@@ -212,7 +212,7 @@ class MapFacetContents extends React.Component<MapFacetContentsDefaultProps, Map
           longitude = value.longitude;
           latitude = value.latitude;
         }
-        if (isNaN(longitude) || isNaN(latitude)) {
+        if (Number.isNaN(longitude) || Number.isNaN(latitude)) {
           return null;
         }
         // Keep track of the boundaries of the coordinates

--- a/src/components/MapFacetContents.js
+++ b/src/components/MapFacetContents.js
@@ -200,14 +200,24 @@ class MapFacetContents extends React.Component<MapFacetContentsDefaultProps, Map
 
       const points = this.props.buckets.map((bucket) => {
         const value = bucket.value; // JSON.parse(bucket.value);
+        let longitude = 0;
+        let latitude = 0;
+        if (typeof value === 'string') {
+          const valueArr = value.split(',');
+          longitude = valueArr[0];
+          latitude = valueArr[1];
+        } else {
+          longitude = value.longitude;
+          latitude = value.latitude;
+        }
         // Keep track of the boundaries of the coordinates
         return (
           <Marker
-            coordinates={[value.longitude || 0, value.latitude || 0]}
+            coordinates={[longitude || 0, latitude || 0]}
             onClick={() => {
               this.props.addFacetFilter(bucket);
             }}
-            key={`${value.longitude || 0},${value.latitude || 0}`}
+            key={`${longitude || 0},${latitude || 0}`}
             style={{ cursor: 'pointer' }}
           >
             <Glyphicon glyph="map-marker" style={{ fontSize: '18px', color: '#2a689c' }} />


### PR DESCRIPTION
[PLAT-44229](https://jira.attivio.com/browse/PLAT-44229) : Incorrect location pointer in Map facet in searchui

GeoMaps in SearchUI points to the location [0,0] even though the pointer has the correct co-ordinates for locations. This results in the map plotting only 1 point at [0,0] which is incorrect. This bug was introduced in 5.6.1 as `SearchFacetBucket.value` returned from the backend API has the co-ordinates in string format `"<longitude>,<latitude>"`. However, UI expects value to be an object in the form of `{longitude: <longitude_value>, latitude: <latitude_value>}`.

Thus, the fix for this issue is to check if `SearchFacetBucket.value` is a string or an object, before passing it to the Mapbox component.