### PR TITLE
imprv/PLAT-43259 : Ensure Promotions are rendered even when search has no results

### DIFF
--- a/src/components/PlacementResults.js
+++ b/src/components/PlacementResults.js
@@ -19,7 +19,7 @@ export default class PlacementResults extends React.Component<void, {}, void> {
   renderResults() {
     const searcher = this.context.searcher;
     const response = searcher.state.response;
-    if (response && response.placements && response.documents.length > 0) {
+    if (response && response.placements) {
       const placements = response.placements;
       const results = [];
       let markupCount = 0;


### PR DESCRIPTION
[PLAT-43259](https://jira.attivio.com/browse/PLAT-43259) : Searchui - Decouple Promotions from Results

When no results are found in searchui, promotions are not displayed. 
In PlacementResults.js, there is a condition to check if any documents are returned by the search. If not, PlacementResult is not rendered. This condition is removed as part of this fix.