### PR TITLE
bug/PLAT-40591 : Do not render facet filters that are already applied to search

### DIFF
--- a/documentation/components/TagCloud.md
+++ b/documentation/components/TagCloud.md
@@ -48,3 +48,27 @@ __2.__ Limiting the results to 5 tags.
     }}
   />
 ```
+
+__3.__ Showing a variety of levels with 2 disabled tags (California & Alaska).
+
+```jsx
+  <TagCloud
+    tags={[
+      new TagCloud.TagCloudValue('Alaska', 741894, true),
+      new TagCloud.TagCloudValue('Alabama', 4863000),
+      new TagCloud.TagCloudValue('California', 39250017, true),
+      new TagCloud.TagCloudValue('Georgia', 10310371),
+      new TagCloud.TagCloudValue('Wisconsin', 5778708),
+      new TagCloud.TagCloudValue('Louisiana', 4681666),
+      new TagCloud.TagCloudValue('Florida', 20612439),
+      new TagCloud.TagCloudValue('Massachusetts', 6811779),
+      new TagCloud.TagCloudValue('Rhode Island', 1056426),
+      new TagCloud.TagCloudValue('Wyoming', 585501),
+      new TagCloud.TagCloudValue('District of Columbia', 681170),
+      new TagCloud.TagCloudValue('Midway Atoll', 75),
+    ]}
+    callback={(value) => {
+      alert(`The user clicked the cloud item ${value.label} whose population is ${value.value}.`);
+    }}
+  />
+```

--- a/documentation/style/bootstrap/attivio-search-results.less
+++ b/documentation/style/bootstrap/attivio-search-results.less
@@ -696,6 +696,10 @@
 	padding: 0.4375rem;
 	transition: all .2s ease-in-out;
 }
+.attivio-cloud li:hover.attivio-cloud-noLink,
+.attivio-cloud li:focus.attivio-cloud-noLink {
+    transform:scale(1);
+}
 .attivio-cloud li:hover,
 .attivio-cloud li:focus {
     transform:scale(1.1);

--- a/src/components/FacetResults.js
+++ b/src/components/FacetResults.js
@@ -141,15 +141,10 @@ export default class FacetResults extends React.Component<FacetResultsDefaultPro
    * Filter Buckets in Facet that are already applied to the search filters.
    * Buckets of type tagcloud and timeseries do not need to be filtered.
    */
-  filterFacetBuckets(facet: SearchFacet, type: string): SearchFacet {
+  filterFacetBuckets = (facet: SearchFacet, type: string, facetFiltersMap: Map<string, FacetFilter>): SearchFacet => {
     if (type === 'tagcloud' || type === 'timeseries') {
       return facet;
     }
-    const facetFilters = this.context.searcher.state.facetFilters;
-    const facetFiltersMap: Map<string, FacetFilter> = new Map();
-    facetFilters.forEach((facetFilter: FacetFilter) => {
-      facetFiltersMap.set(facetFilter.filter, facetFilter);
-    });
     const filteredBuckets = [];
     facet.buckets.forEach((bucket: SearchFacetBucket) => {
       if (!facetFiltersMap.get(bucket.filter)) {
@@ -167,12 +162,17 @@ export default class FacetResults extends React.Component<FacetResultsDefaultPro
       facets.forEach((facet: SearchFacet) => {
         facetsMap.set(facet.name, facet);
       });
+      const facetFilters = this.context.searcher.state.facetFilters;
+      const facetFiltersMap: Map<string, FacetFilter> = new Map();
+      facetFilters.forEach((facetFilter: FacetFilter) => {
+        facetFiltersMap.set(facetFilter.filter, facetFilter);
+      });
       const results = [];
       this.props.orderHint.forEach((facetName) => {
         const facet = facetsMap.get(facetName);
         if (facet && this.shouldShow(facet)) {
           const type = this.getFacetDisplayType(facet.field);
-          const filteredFacet = this.filterFacetBuckets(facet, type);
+          const filteredFacet = this.filterFacetBuckets(facet, type, facetFiltersMap);
           results.push(<Facet
             facet={filteredFacet}
             type={type}
@@ -187,7 +187,7 @@ export default class FacetResults extends React.Component<FacetResultsDefaultPro
         if (!this.props.orderHint.includes(facet.name)) {
           if (this.shouldShow(facet)) {
             const type = this.getFacetDisplayType(facet.field);
-            const filteredFacet = this.filterFacetBuckets(facet, type);
+            const filteredFacet = this.filterFacetBuckets(facet, type, facetFiltersMap);
             results.push(<Facet
               facet={filteredFacet}
               type={type}

--- a/src/components/Searcher.js
+++ b/src/components/Searcher.js
@@ -935,12 +935,6 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
    */
   addFacetFilter(facetName: string, bucketLabel: string, filter: string) {
     const updatedFacetFilters = this.state.facetFilters ? this.state.facetFilters : [];
-    const filterAlreadyExisting = updatedFacetFilters.some((facetFilter: FacetFilter) => {
-      return facetFilter.filter === filter;
-    });
-    if (filterAlreadyExisting) {
-      return;
-    }
     const newFF = new FacetFilter();
     newFF.facetName = facetName;
     newFF.bucketLabel = bucketLabel;

--- a/src/components/Searcher.js
+++ b/src/components/Searcher.js
@@ -930,22 +930,22 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
   /**
    * Add a facet filter to the current search. Will repeat the search
    * if it's already been performed. Note that if a filter for the
-   * same facet name already exists, it will be replaced with the
-   * new one.
+   * same facet name already exists, it will add the new filter
+   * instead of replacing.
    */
   addFacetFilter(facetName: string, bucketLabel: string, filter: string) {
+    const updatedFacetFilters = this.state.facetFilters ? this.state.facetFilters : [];
+    const filterAlreadyExisting = updatedFacetFilters.some((facetFilter: FacetFilter) => {
+      return facetFilter.filter === filter;
+    });
+    if (filterAlreadyExisting) {
+      return;
+    }
     const newFF = new FacetFilter();
     newFF.facetName = facetName;
     newFF.bucketLabel = bucketLabel;
     newFF.filter = filter;
 
-    const updatedFacetFilters = [];
-    const facetFilters = this.state.facetFilters;
-    facetFilters.forEach((facetFilter) => {
-      if (facetFilter.facetName !== facetName) {
-        updatedFacetFilters.push(facetFilter);
-      }
-    });
     updatedFacetFilters.push(newFF);
     this.updateStateResetAndSearch({
       facetFilters: updatedFacetFilters,

--- a/src/components/TagCloud.js
+++ b/src/components/TagCloud.js
@@ -7,10 +7,13 @@ export class TagCloudValue {
   label: string;
   /** The value for this item. */
   value: number;
+  /** Whether the tag should be clickable */
+  noLink: boolean;
 
-  constructor(label: string, value: number) {
+  constructor(label: string, value: number, noLink: boolean) {
     this.label = label;
     this.value = value;
+    this.noLink = noLink;
   }
 }
 
@@ -134,7 +137,8 @@ export default class TagCloud extends React.Component<TagCloudDefaultProps, TagC
       };
       const className = TagCloud.getClassNameForLevel(size);
       return (
-        this.props.noLink ? (<li key={tcv.label}>
+        (this.props.noLink || tcv.noLink) ? 
+        (<li key={tcv.label} className="attivio-cloud-noLink">
           <span className={className}>
             {tcv.label}
           </span>

--- a/src/components/TagCloud.js
+++ b/src/components/TagCloud.js
@@ -137,7 +137,7 @@ export default class TagCloud extends React.Component<TagCloudDefaultProps, TagC
       };
       const className = TagCloud.getClassNameForLevel(size);
       return (
-        (this.props.noLink || tcv.noLink) ? 
+        (this.props.noLink || tcv.noLink) ?
         (<li key={tcv.label} className="attivio-cloud-noLink">
           <span className={className}>
             {tcv.label}

--- a/src/components/TagCloud.js
+++ b/src/components/TagCloud.js
@@ -10,7 +10,7 @@ export class TagCloudValue {
   /** Whether the tag should be clickable */
   noLink: boolean;
 
-  constructor(label: string, value: number, noLink: boolean) {
+  constructor(label: string, value: number, noLink: boolean = false) {
     this.label = label;
     this.value = value;
     this.noLink = noLink;
@@ -31,7 +31,9 @@ type TagCloudProps = {
    * object if one is clicked.
    */
   callback: (tcv: TagCloudValue) => void;
-
+  /**
+   * boolean condition to remove hyperlinks from tags and show them as plain text
+   */
   noLink: boolean;
 };
 
@@ -136,17 +138,18 @@ export default class TagCloud extends React.Component<TagCloudDefaultProps, TagC
         event.target.blur();
       };
       const className = TagCloud.getClassNameForLevel(size);
-      return (
-        (this.props.noLink || tcv.noLink) ?
-        (<li key={tcv.label} className="attivio-cloud-noLink">
+      return (this.props.noLink || tcv.noLink) ? (
+        <li key={tcv.label} className="attivio-cloud-noLink">
           <span className={className}>
             {tcv.label}
           </span>
-        </li>) : (<li key={tcv.label}>
+        </li>
+      ) : (
+        <li key={tcv.label}>
           <a className={className} onClick={callback} role="button" tabIndex={0}>
             {tcv.label}
           </a>
-        </li>)
+        </li>
       );
     });
 

--- a/src/components/TagCloudFacetContents.js
+++ b/src/components/TagCloudFacetContents.js
@@ -58,7 +58,8 @@ export default class TagCloudFacetContents extends React.Component<TagCloudFacet
    * The tag should be noLink or non-clickable if the respective tag is applied to the filter.
    */
   isTagNoLink(bucket: SearchFacetBucket): boolean {
-    const facetFilters = this.context.searcher.state.facetFilters;
+    const searcher = this.context.searcher;
+    const facetFilters = searcher ? searcher.state.facetFilters : [];
     const isBucketFilterApplied = facetFilters.some((facetFilter: FacetFilter) => {
       return facetFilter.filter === bucket.filter;
     });

--- a/src/components/TagCloudFacetContents.js
+++ b/src/components/TagCloudFacetContents.js
@@ -1,8 +1,10 @@
 // @flow
 
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import SearchFacetBucket from '../api/SearchFacetBucket';
+import FacetFilter from '../api/FacetFilter';
 import TagCloud, { TagCloudValue } from './TagCloud';
 
 type TagCloudFacetContentsProps = {
@@ -32,6 +34,10 @@ export default class TagCloudFacetContents extends React.Component<TagCloudFacet
     noLink: false,
   };
 
+  static contextTypes = {
+    searcher: PropTypes.any,
+  };
+
   constructor(props: TagCloudFacetContentsProps) {
     super(props);
     (this: any).tagCloudCallback = this.tagCloudCallback.bind(this);
@@ -47,10 +53,23 @@ export default class TagCloudFacetContents extends React.Component<TagCloudFacet
     }
   }
 
+  /**
+   * Check if the search filter already has this bucket filter applied.
+   * The tag should be noLink or non-clickable if the respective tag is applied to the filter.
+   */
+  isTagNoLink(bucket: SearchFacetBucket): boolean {
+    const facetFilters = this.context.searcher.state.facetFilters;
+    const isBucketFilterApplied = facetFilters.some((facetFilter: FacetFilter) => {
+      return facetFilter.filter === bucket.filter;
+    });
+    return isBucketFilterApplied;
+  }
+
   render() {
     const tagCloudValues = this.props.buckets.map((bucket) => {
       const bucketLabel = bucket.displayLabel();
-      return new TagCloudValue(bucketLabel, bucket.count);
+      const noLink = this.isTagNoLink(bucket);
+      return new TagCloudValue(bucketLabel, bucket.count, noLink);
     });
 
     return (


### PR DESCRIPTION
[PLAT-40591](https://jira.attivio.com/browse/PLAT-40591) : When a facet is applied, that facet should not be rendered

While applying filters in searchui, following changes in the behavior of Facets are applied:
- A facet now allows to add multiple filters based on buckets of same Facet.
- If a particular facet bucket is applied as a filter, then that bucket won't be shown in the Facet (except Facts of type 'tagcloud' and 'timeseries').
- If a facet has buckets where all the buckets are used as filters, the facet won't be displayed.