### PR TITLE
issue-153: Fix to prevent autocomplete shakiness when updating suggestions

### DIFF
--- a/src/components/AutoCompleteInput.js
+++ b/src/components/AutoCompleteInput.js
@@ -110,7 +110,6 @@ export default class AutoCompleteInput extends React.Component<AutoCompleteInput
           isLoading: true,
           open: true,
           error: '',
-          suggestions: [],
           queryValue: query,
           userInput: query,
           queryTimestamp: Date.now(),


### PR DESCRIPTION
Remove a line causing the autocomplete to flicker because it was setting suggestions to empty before fetching new suggestions, when it is better to just update with the new suggestions once they have been retrieved 