### PR TITLE
Task/plat 44218 : Add signals to promotions

### DIFF
--- a/src/api/SignalData.js
+++ b/src/api/SignalData.js
@@ -4,6 +4,39 @@
  * Signal data needed for doing click tracking, etc., with a document.
  */
 export default class SignalData {
+
+  constructor(
+    docId: string = '',
+    docOrdinal: number = -1,
+    featureVector: string = '',
+    locale: string = '',
+    principal: string = '',
+    query: string = '',
+    queryTimestamp: number = 0,
+    relevancyModelName: string = '',
+    relevancyModelNames: Array<string> = [],
+    relevancyModelVersion: number = 1,
+    signalTimestamp: number = 0,
+    ttl: boolean = true,
+    type: string = '',
+    weight: number = 1,
+  ) {
+    this.docId = docId;
+    this.docOrdinal = docOrdinal;
+    this.featureVector = featureVector;
+    this.locale = locale;
+    this.principal = principal;
+    this.query = query;
+    this.queryTimestamp = queryTimestamp;
+    this.relevancyModelName = relevancyModelName;
+    this.relevancyModelNames = relevancyModelNames;
+    this.relevancyModelVersion = relevancyModelVersion;
+    this.signalTimestamp = signalTimestamp;
+    this.ttl = ttl;
+    this.type = type;
+    this.weight = weight;
+  }
+
   docId: string;
   docOrdinal: number;
   featureVector: string;
@@ -43,5 +76,24 @@ export default class SignalData {
   updateForTracking(type: string = 'click', weight: number = 1) {
     this.type = type;
     this.weight = weight;
+  }
+
+  clone(): SignalData {
+    return new SignalData(
+      this.docId,
+      this.docOrdinal,
+      this.featureVector,
+      this.locale,
+      this.principal,
+      this.query,
+      this.queryTimestamp,
+      this.relevancyModelName,
+      this.relevancyModelNames,
+      this.relevancyModelVersion,
+      this.signalTimestamp,
+      this.ttl,
+      this.type,
+      this.weight,
+    );
   }
 }

--- a/src/components/PlacementResult.js
+++ b/src/components/PlacementResult.js
@@ -46,7 +46,7 @@ export default class PlacementResult extends React.Component<PlacementResultDefa
     if (!addPromotionSignal) {
       return;
     }
-    const signalDocId = imageUrl ? `${imageUrl}-${linkUrl}` : `${linkText}-${linkUrl}`;
+    const signalDocId = imageUrl ? `${imageUrl}-${linkUrl || ''}` : `${linkText || ''}-${linkUrl || ''}`;
     const signalDocOrdinal = imageUrl ? 2 : 1;
     addPromotionSignal(signalDocId, signalDocOrdinal);
   }

--- a/src/components/PlacementResult.js
+++ b/src/components/PlacementResult.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Card from './Card';
 
@@ -33,6 +34,22 @@ export default class PlacementResult extends React.Component<PlacementResultDefa
   }
 
   static displayName = 'PlacementResult';
+
+  static contextTypes = {
+    searcher: PropTypes.any,
+  };
+
+  onPromotionClick() {
+    const { linkUrl, linkText, imageUrl } = this.props;
+    const searcher = this.context.searcher;
+    const addPromotionSignal = searcher ? searcher.addPromotionSignal : null;
+    if (!addPromotionSignal) {
+      return;
+    }
+    const signalDocId = imageUrl ? `${imageUrl}-${linkUrl}` : `${linkText}-${linkUrl}`;
+    const signalDocOrdinal = imageUrl ? 2 : 1;
+    addPromotionSignal(signalDocId, signalDocOrdinal);
+  }
 
   renderMarkupIframe() {
     const getBlobURL = (code) => {
@@ -83,7 +100,7 @@ export default class PlacementResult extends React.Component<PlacementResultDefa
     return (
       <Card style={{ marginBottom: '10px' }}>
         {this.props.linkUrl ? (
-          <a href={this.props.linkUrl} >
+          <a href={this.props.linkUrl} onClick={() => this.onPromotionClick()} >
             {contents}
           </a>
         ) : contents}

--- a/src/components/PlacementResult.js
+++ b/src/components/PlacementResult.js
@@ -39,16 +39,19 @@ export default class PlacementResult extends React.Component<PlacementResultDefa
     searcher: PropTypes.any,
   };
 
-  onPromotionClick() {
+  onPromotionClick = () => {
     const { linkUrl, linkText, imageUrl } = this.props;
     const searcher = this.context.searcher;
-    const addPromotionSignal = searcher ? searcher.addPromotionSignal : null;
-    if (!addPromotionSignal) {
+    if (!searcher) {
       return;
     }
-    const signalDocId = imageUrl ? `${imageUrl}-${linkUrl || ''}` : `${linkText || ''}-${linkUrl || ''}`;
+    // The docId for the signal is of the format:
+    // '{Display Text} - {Destination Link}' -- if the promotion is Link
+    // '{Image URL} - {Destination Link}' -- if the promotion is Image
+    // The docOrdinal for link promotion is 1 and image promotion is 2
+    const signalDocId = imageUrl ? `${imageUrl} - ${linkUrl || ''}` : `${linkText || ''} - ${linkUrl || ''}`;
     const signalDocOrdinal = imageUrl ? 2 : 1;
-    addPromotionSignal(signalDocId, signalDocOrdinal);
+    searcher.addPromotionSignal(signalDocId, signalDocOrdinal);
   }
 
   renderMarkupIframe() {
@@ -100,7 +103,7 @@ export default class PlacementResult extends React.Component<PlacementResultDefa
     return (
       <Card style={{ marginBottom: '10px' }}>
         {this.props.linkUrl ? (
-          <a href={this.props.linkUrl} onClick={() => this.onPromotionClick()} >
+          <a href={this.props.linkUrl} onClick={this.onPromotionClick} >
             {contents}
           </a>
         ) : contents}

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -191,14 +191,11 @@ class SearchBar extends React.Component<SearchBarDefaultProps, SearchBarProps, S
     if (!signalType || !savedUser) {
       return;
     }
-    const signal = new SignalData();
+    const signal = signalData.clone();
     signal.docId = query;
-    signal.docOrdinal = signalData.docOrdinal;
     signal.featureVector = '';
     signal.locale = 'en';
     signal.principal = `${AuthUtils.config.ALL.defaultRealm}:${savedUser.fullName}:${savedUser.userId}`;
-    signal.query = signalData.query;
-    signal.queryTimestamp = signalData.queryTimestamp;
     signal.relevancyModelName = 'default';
     signal.relevancyModelNames = ['default'];
     signal.relevancyModelVersion = 1;

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -203,7 +203,6 @@ class SearchBar extends React.Component<SearchBarDefaultProps, SearchBarProps, S
     signal.relevancyModelNames = ['default'];
     signal.relevancyModelVersion = 1;
     signal.signalTimestamp = Date.now();
-    signal.ttl = false;
     signal.type = 'autocomplete';
     signal.weight = 1;
 

--- a/src/components/Searcher.js
+++ b/src/components/Searcher.js
@@ -1008,7 +1008,6 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
     signal.relevancyModelNames = querySignal.relevancyModelNames;
     signal.relevancyModelVersion = querySignal.relevancyModelVersion;
     signal.signalTimestamp = Date.now();
-    signal.ttl = false;
     signal.type = 'facet';
     signal.weight = weight;
 

--- a/src/components/Searcher.js
+++ b/src/components/Searcher.js
@@ -399,6 +399,15 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
     };
   }
 
+  getRelevancyModels(): string[] {
+    if (this.state.relevancyModels && this.state.relevancyModels.length > 0) {
+      return this.state.relevancyModels;
+    } else if (this.props.relevancyModels && this.props.relevancyModels.length > 0) {
+      return this.props.relevancyModels;
+    }
+    return [];
+  }
+
   /**
    * Use the properties of the Searcher component and the values from its
    * current state to generate a query request object that will be passed
@@ -431,11 +440,8 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
     // the restParams property.
     const restParams = new Map();
     restParams.set('offset', [`${this.state.resultsOffset}`]);
-    if (this.state.relevancyModels && this.state.relevancyModels.length > 0) {
-      restParams.set('relevancymodelnames', [this.state.relevancyModels.join(',')]);
-    } else if (this.props.relevancyModels && this.props.relevancyModels.length > 0) {
-      restParams.set('relevancymodelnames', [this.props.relevancyModels.join(',')]);
-    }
+    const relevancyModels = this.getRelevancyModels();
+    restParams.set('relevancymodelnames', [relevancyModels.join(',')]);
     restParams.set('includemetadatainresponse', ['true']);
     if (this.props.highlightResults) {
       restParams.set('highlight', ['true']);
@@ -515,14 +521,15 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
     if (createNewIfNotExisting) {
       const savedUser = AuthUtils.getSavedUser();
       const defaultSignalData = new SignalData();
-      const { query, queryTimestamp, relevancyModels } = this.state;
+      const { query, queryTimestamp } = this.state;
+      const relevancyModels = this.getRelevancyModels();
       if (savedUser) {
         defaultSignalData.locale = 'en';
         defaultSignalData.principal = `${AuthUtils.config.ALL.defaultRealm}:${savedUser.fullName}:${savedUser.userId}`;
         defaultSignalData.query = query;
         defaultSignalData.queryTimestamp = queryTimestamp;
         defaultSignalData.relevancyModelName = relevancyModels[0] || 'default';
-        defaultSignalData.relevancyModelNames = relevancyModels && relevancyModels.length > 0 ? relevancyModels : ['default'];
+        defaultSignalData.relevancyModelNames = relevancyModels.length > 0 ? relevancyModels : ['default'];
         defaultSignalData.relevancyModelVersion = 1;
       }
       return defaultSignalData;

--- a/src/components/Searcher.js
+++ b/src/components/Searcher.js
@@ -1033,8 +1033,8 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
       return;
     }
     // The signals for adding and removing the facet have the same docId and
-    // thus same signal is created for them. Thus, we add a suffix '|add' or '\remove'
-    // to denote whether the signal is for adding or removing facts and
+    // thus same signal is created for them. Thus, we add a suffix '|add' or '|remove'
+    // to denote whether the signal is for adding or removing facets and
     // also to differentiate both the signals on backend.
     const docIDSuffix = facetAdded ? '|add' : '|remove';
     const signal = querySignal.clone();

--- a/src/components/Searcher.js
+++ b/src/components/Searcher.js
@@ -994,8 +994,9 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
     if (!facet) {
       return;
     }
+    const docIDSuffix = (weight === 1) ? '-add' : '-remove';
     const signal = new SignalData();
-    signal.docId = facetFilter.filter;
+    signal.docId = facetFilter.filter.concat(docIDSuffix);
     signal.docOrdinal = facet.buckets.findIndex((bucket) => {
       return bucket.filter === facetFilter.filter;
     }) + 1; // index starts at 1

--- a/src/components/Searcher.js
+++ b/src/components/Searcher.js
@@ -399,7 +399,7 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
     };
   }
 
-  getRelevancyModels(): string[] {
+  getRelevancyModels(): Array<string> {
     if (this.state.relevancyModels && this.state.relevancyModels.length > 0) {
       return this.state.relevancyModels;
     } else if (this.props.relevancyModels && this.props.relevancyModels.length > 0) {
@@ -528,8 +528,8 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
         defaultSignalData.principal = `${AuthUtils.config.ALL.defaultRealm}:${savedUser.fullName}:${savedUser.userId}`;
         defaultSignalData.query = query;
         defaultSignalData.queryTimestamp = queryTimestamp;
-        defaultSignalData.relevancyModelName = relevancyModels[0] || 'default';
-        defaultSignalData.relevancyModelNames = relevancyModels.length > 0 ? relevancyModels : ['default'];
+        defaultSignalData.relevancyModelName = relevancyModels[0] || '';
+        defaultSignalData.relevancyModelNames = relevancyModels.length > 0 ? relevancyModels : [];
         defaultSignalData.relevancyModelVersion = 1;
       }
       return defaultSignalData;


### PR DESCRIPTION
[PLAT-44218](https://jira.attivio.com/browse/PLAT-44218) : Add signals to promotions

This PR is to add signal when a promotion (link or image) is clicked. Additionally, for other types of signals being added, `signal.ttl` is removed from the request to ensure it is defaulted to `true` from backend.
Also, the creation of signal for facet filter is refactored to ensure `-add` or `-remove` is suffixed to `signal.docId` when a facet is added or removed.