### PR TITLE
feat/PLAT-44338 : Allow the mast head to be hidden if the url contains /no-mast

### DIFF
--- a/src/components/Masthead.js
+++ b/src/components/Masthead.js
@@ -244,6 +244,18 @@ class Masthead extends React.Component<MastheadDefaultProps, MastheadProps, Mast
       logoutFunction = null;
     }
 
+    const hideMast = this.context.searcher.state.hideMast || false;
+    if (hideMast) {
+      return (
+        <header className="attivio-globalmast attivio-minwidth">
+          <div className="attivio-container">
+            {this.props.children}
+            <div className="attivio-globalmast-spacer attivio-globalmast-logo" />
+          </div>
+        </header>
+      );
+    }
+
     return (
       <header className="attivio-globalmast attivio-minwidth">
         <div className="attivio-container">

--- a/src/components/Searcher.js
+++ b/src/components/Searcher.js
@@ -208,6 +208,7 @@ type SearcherState = {
   resultsOffset: number;
   debug: boolean;
   queryTimestamp: number;
+  hideMast: boolean;
 };
 
 /**
@@ -396,6 +397,7 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
       resultsOffset: 0,
       debug: this.props.debug,
       queryTimestamp: 0,
+      hideMast: (this.props.location.pathname && this.props.location.pathname.includes('/no-mast')),
     };
   }
 
@@ -548,12 +550,14 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
     delete currentState.response;
     delete currentState.haveSearched;
     delete currentState.queryTimestamp;
+    delete currentState.hideMast;
 
     const newState = Object.assign({}, compareWith);
     delete newState.error;
     delete newState.response;
     delete newState.haveSearched;
     delete newState.queryTimestamp;
+    delete newState.hideMast;
 
     return !ObjectUtils.deepEquals(currentState, newState);
   }
@@ -727,6 +731,7 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
       debug,
       haveSearched: this.state.haveSearched, // Make sure we don't change this
       queryTimestamp: 0,
+      hideMast: this.state.hideMast, // Ignored as it does not apply to the search string
     };
 
     return result;


### PR DESCRIPTION
[PLAT-44338](https://jira.attivio.com/browse/PLAT-44338): Clicking Search should render SearchUI

Admin 2.0 requires Search UI to be rendered without the Attivio logo, application name and the logged in user info in the mast, when `/no-mast` path is included in the url.

To hide the above elements from the attivio mast, we intercept the URL in `<Searcher>` and set the `hideMast` var to true if the URL contains `/no-mast`. In `<Masthead>`, if `context.searcher.state.hideMast` is set, we render a minimal view of the masthead that does not contain the attivio logo, application name and the logged in user info.

Additionally, when the logo was removed from the mast, the height of the mast was suppressed. Currently, the height of the mast was derived from the css class `attivio-globalmast-logo` which is part of the logo element. Thus, to have the same height of the mast in the minimal view, class `attivio-globalmast-logo` is added the `<div>` in the container.