### PR TITLE
feat/PLAT-44338 : Allow the mast head to be hidden if the url contains /no-mast

### DIFF
--- a/src/components/DebugSearchResult.js
+++ b/src/components/DebugSearchResult.js
@@ -26,6 +26,12 @@ type DebugSearchResultProps = {
   showTags: boolean;
   /** Whether star ratings should be shown in the UI or not. Defaults to true. */
   showRatings: boolean;
+  /**
+   * Optional.
+   * The Doc 360 page URL that should be rendered when the user clicks
+   * on "Show 360° View" button. This would default to '/doc360' if
+   * nothing provided.
+   */
   url360Page?: string;
 }
 

--- a/src/components/DebugSearchResult.js
+++ b/src/components/DebugSearchResult.js
@@ -26,12 +26,14 @@ type DebugSearchResultProps = {
   showTags: boolean;
   /** Whether star ratings should be shown in the UI or not. Defaults to true. */
   showRatings: boolean;
+  url360Page?: string;
 }
 
 type DebugSearchResultDefaultProps = {
   baseUri: string;
   showTags: boolean;
   showRatings: boolean;
+  url360Page: string;
 }
 
 /**
@@ -42,6 +44,7 @@ export default class DebugSearchResult extends React.Component<DebugSearchResult
     baseUri: '',
     showTags: true,
     showRatings: true,
+    url360Page: '',
   };
 
   static displayName = 'DebugSearchResult';
@@ -49,9 +52,9 @@ export default class DebugSearchResult extends React.Component<DebugSearchResult
   /**
    * Renders a <DebugSearchResult> component for the document.
    */
-  static renderer(doc: SearchDocument, position: number, baseUri: string, key: string) {
+  static renderer(doc: SearchDocument, position: number, baseUri: string, key: string, url360Page: string) {
     return (
-      <DebugSearchResult document={doc} position={position} baseUri={baseUri} key={key} />
+      <DebugSearchResult document={doc} position={position} baseUri={baseUri} key={key} url360Page={url360Page} />
     );
   }
 
@@ -89,6 +92,7 @@ export default class DebugSearchResult extends React.Component<DebugSearchResult
     const scoreDescription = doc.getFirstValue(FieldNames.SCORE_EXPLAIN);
     const moreLikeThisQuery = doc.getFirstValue('morelikethisquery');
     const docTags = doc.getAllValues('tags');
+    const url360Page = this.props.url360Page;
 
     const fieldRows = [];
     const fieldNames = this.props.document.fields.keys();
@@ -143,7 +147,7 @@ export default class DebugSearchResult extends React.Component<DebugSearchResult
             {fieldRows}
           </dl>
           {this.props.showTags ? (
-            <SearchResultTags tags={docTags} moreLikeThisQuery={moreLikeThisQuery} vertical docId={docId} />
+            <SearchResultTags tags={docTags} moreLikeThisQuery={moreLikeThisQuery} vertical docId={docId} url360Page={url360Page} />
           ) : null}
         </div>
       </div>

--- a/src/components/Doc360Breadcrumbs.js
+++ b/src/components/Doc360Breadcrumbs.js
@@ -11,6 +11,12 @@ type Doc360BreadcrumbsProps = {
   currentDoc: SearchDocument;
   location: PropTypes.object.isRequired;
   history: PropTypes.object.isRequired;
+  /**
+   * Optional.
+   * The results page URL that should be rendered when the user clicks
+   * on "Results List" link. This would default to '/results' if
+   * nothing provided.
+   */
   urlResultsPage?: string;
 };
 

--- a/src/components/Doc360Breadcrumbs.js
+++ b/src/components/Doc360Breadcrumbs.js
@@ -11,6 +11,7 @@ type Doc360BreadcrumbsProps = {
   currentDoc: SearchDocument;
   location: PropTypes.object.isRequired;
   history: PropTypes.object.isRequired;
+  urlResultsPage?: string;
 };
 
 class HistoryEntry {
@@ -99,8 +100,9 @@ class Doc360Breadcrumbs extends React.Component<void, Doc360BreadcrumbsProps, Do
   }
 
   render() {
+    const urlResultsPage = this.props.urlResultsPage || '/results';
     // Start with the base location, which is always the search results page
-    const crumbs = [new BreadcrumbInfo('Results List', { pathname: '/results', search: this.props.location.search })];
+    const crumbs = [new BreadcrumbInfo('Results List', { pathname: urlResultsPage, search: this.props.location.search })];
     this.state.history.forEach((entry) => {
       crumbs.push(new BreadcrumbInfo(entry.label, entry.location));
     });

--- a/src/components/ListSearchResult.js
+++ b/src/components/ListSearchResult.js
@@ -37,6 +37,7 @@ type InnerListSearchResultProps = {
   showTags: boolean;
   /** Whether star ratings should be shown in the UI or not. Defaults to true. */
   showRatings: boolean;
+  url360Page: string;
 }
 
 type InnerListSearchResultDefaultProps = {
@@ -45,6 +46,7 @@ type InnerListSearchResultDefaultProps = {
   entityFields: Map<string, string>;
   showTags: boolean;
   showRatings: boolean;
+  url360Page: string;
 }
 
 type InnerListSearchResultState = {
@@ -62,6 +64,7 @@ class InnerListSearchResult extends React.Component<InnerListSearchResultDefault
     entityFields: new Map([['people', 'People'], ['location', 'Locations'], ['company', 'Companies']]),
     showTags: true,
     showRatings: true,
+    url360Page: '',
   };
 
   static displayName = 'ListSearchResult';
@@ -73,9 +76,9 @@ class InnerListSearchResult extends React.Component<InnerListSearchResultDefault
   /**
    * Renders a <ListSearchResult> component for the document.
    */
-  static renderer(doc: SearchDocument, position: number, baseUri: string, key: string) {
+  static renderer(doc: SearchDocument, position: number, baseUri: string, key: string, url360Page: string) {
     return (
-      <ListSearchResult document={doc} position={position} baseUri={baseUri} key={key} />
+      <ListSearchResult document={doc} position={position} baseUri={baseUri} key={key} url360Page={url360Page} />
     );
   }
 
@@ -133,6 +136,7 @@ class InnerListSearchResult extends React.Component<InnerListSearchResultDefault
     const text = doc.getFirstValue('teaser');
     const moreLikeThisQuery = doc.getFirstValue('morelikethisquery');
     const docTags = doc.getAllValues('tags');
+    const url360Page = this.props.url360Page;
 
     let nestedDocs = null;
     if (doc.children && doc.children.length > 0) {
@@ -158,6 +162,7 @@ class InnerListSearchResult extends React.Component<InnerListSearchResultDefault
               key={tableDoc.getFirstValue('.id')}
               position={childPosition}
               baseUri={this.props.baseUri}
+              url360Page={url360Page}
             />
           );
         });
@@ -215,7 +220,7 @@ class InnerListSearchResult extends React.Component<InnerListSearchResultDefault
             <Col xs={7} sm={7}>
               <SearchResultBody body={text} />
               {this.props.showTags ? (
-                <SearchResultTags tags={docTags} moreLikeThisQuery={moreLikeThisQuery} docId={docId} />
+                <SearchResultTags tags={docTags} moreLikeThisQuery={moreLikeThisQuery} docId={docId} url360Page={url360Page} />
               ) : null}
             </Col>
             <Col xs={5} sm={5}>

--- a/src/components/ListSearchResult.js
+++ b/src/components/ListSearchResult.js
@@ -37,7 +37,13 @@ type InnerListSearchResultProps = {
   showTags: boolean;
   /** Whether star ratings should be shown in the UI or not. Defaults to true. */
   showRatings: boolean;
-  url360Page: string;
+  /**
+   * Optional.
+   * The Doc 360 page URL that should be rendered when the user clicks
+   * on "Show 360° View" button. This would default to '/doc360' if
+   * nothing provided.
+   */
+  url360Page?: string;
 }
 
 type InnerListSearchResultDefaultProps = {

--- a/src/components/Masthead.js
+++ b/src/components/Masthead.js
@@ -47,6 +47,8 @@ type MastheadProps = {
   logoutFunction: null | () => void,
   /** The contents of the Masthead can be arbitrary components. */
   children: Children;
+  /** If set, renders a minimal view of the Masthead with only children components rendered */
+  simple: boolean;
 };
 
 type MastheadDefaultProps = {
@@ -60,6 +62,7 @@ type MastheadDefaultProps = {
   helpUri: string | null;
   username: string | null;
   logoutFunction: null | () => void,
+  simple: boolean;
 };
 
 type MastheadState = {
@@ -85,6 +88,7 @@ class Masthead extends React.Component<MastheadDefaultProps, MastheadProps, Mast
     searchEngineType: 'attivio',
     helpUri: null,
     username: null,
+    simple: false,
   }
 
   static contextTypes = {
@@ -244,8 +248,8 @@ class Masthead extends React.Component<MastheadDefaultProps, MastheadProps, Mast
       logoutFunction = null;
     }
 
-    const hideMast = this.context.searcher.state.hideMast || false;
-    if (hideMast) {
+    const simple = this.props.simple;
+    if (simple) {
       return (
         <header className="attivio-globalmast attivio-minwidth">
           <div className="attivio-container">

--- a/src/components/SearchResultTags.js
+++ b/src/components/SearchResultTags.js
@@ -44,6 +44,7 @@ type SearchResultTagsProps = {
   comments?: boolean;
   /** Table field for the comment documents */
   commentsTable?: string;
+  url360Page?: string;
 };
 
 type SearchResultTagsDefaultProps = {
@@ -54,6 +55,7 @@ type SearchResultTagsDefaultProps = {
   baseUri: string,
   comments: boolean,
   commentsTable: string,
+  url360Page: string,
 };
 
 type SearchResultTagsState = {
@@ -84,6 +86,7 @@ class SearchResultTags extends React.Component<SearchResultTagsDefaultProps, Sea
     baseUri: '',
     comments: false,
     commentsTable: 'comments',
+    url360Page: '',
   };
 
   static displayName = 'SearchResultTags';
@@ -207,7 +210,8 @@ class SearchResultTags extends React.Component<SearchResultTagsDefaultProps, Sea
 
   show360View() {
     const escapedDocId = encodeURIComponent(this.props.docId);
-    const path = '/doc360';
+    const url360Page = this.props.url360Page;
+    const path = url360Page || '/doc360';
     const search = QueryString.parse(this.props.location.search);
     search.docId = escapedDocId;
     this.props.history.push({ pathname: path, search: `${QueryString.stringify(search)}` });

--- a/src/components/SearchResultTags.js
+++ b/src/components/SearchResultTags.js
@@ -44,6 +44,12 @@ type SearchResultTagsProps = {
   comments?: boolean;
   /** Table field for the comment documents */
   commentsTable?: string;
+  /**
+   * Optional.
+   * The Doc 360 page URL that should be rendered when the user clicks
+   * on "Show 360° View" button. This would default to '/doc360' if
+   * nothing provided.
+   */
   url360Page?: string;
 };
 

--- a/src/components/SearchResults.js
+++ b/src/components/SearchResults.js
@@ -56,6 +56,12 @@ type SearchResultsProps = {
   showRatings: boolean;
   /** A style to apply to the results list */
   style: any;
+  /**
+   * Optional.
+   * The Doc 360 page URL that should be rendered when the user clicks
+   * on "Show 360° View" button. This would default to '/doc360' if
+   * nothing provided.
+   */
   url360Page?: string;
 };
 

--- a/src/components/SearchResults.js
+++ b/src/components/SearchResults.js
@@ -18,7 +18,8 @@ import SearchDocument from '../api/SearchDocument';
  * rendered by this function. If no SearchResultRenderer functions handle the
  * rendering, then the document will be rendered by the 'list' renderer.
  */
-export type SearchResultRenderer = (doc: SearchDocument, position: number, baseUri: string, key: string) => any;
+export type SearchResultRenderer =
+  (doc: SearchDocument, position: number, baseUri: string, key: string, url360Page?: string) => any;
 
 type SearchResultsProps = {
   /**
@@ -55,6 +56,7 @@ type SearchResultsProps = {
   showRatings: boolean;
   /** A style to apply to the results list */
   style: any;
+  url360Page?: string;
 };
 
 type SearchResultsDefaultProps = {
@@ -64,6 +66,7 @@ type SearchResultsDefaultProps = {
   showTags: boolean;
   showRatings: boolean;
   style: any;
+  url360Page: string;
 };
 
 /**
@@ -78,6 +81,7 @@ export default class SearchResults extends React.Component<SearchResultsDefaultP
     showTags: true,
     showRatings: true,
     style: {},
+    url360Page: '',
   };
 
   static contextTypes = {
@@ -122,7 +126,7 @@ export default class SearchResults extends React.Component<SearchResultsDefaultP
         // will render a result.
         formats.forEach((format: SearchResultRenderer) => {
           if (!renderedDocument) {
-            const possibleResult = format(document, position, this.props.baseUri, key);
+            const possibleResult = format(document, position, this.props.baseUri, key, this.props.url360Page);
             if (possibleResult) {
               renderedDocument = possibleResult;
             }

--- a/src/components/Searcher.js
+++ b/src/components/Searcher.js
@@ -208,7 +208,6 @@ type SearcherState = {
   resultsOffset: number;
   debug: boolean;
   queryTimestamp: number;
-  hideMast: boolean;
 };
 
 /**
@@ -397,7 +396,6 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
       resultsOffset: 0,
       debug: this.props.debug,
       queryTimestamp: 0,
-      hideMast: (this.props.location.pathname && this.props.location.pathname.includes('/no-mast')),
     };
   }
 
@@ -550,14 +548,12 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
     delete currentState.response;
     delete currentState.haveSearched;
     delete currentState.queryTimestamp;
-    delete currentState.hideMast;
 
     const newState = Object.assign({}, compareWith);
     delete newState.error;
     delete newState.response;
     delete newState.haveSearched;
     delete newState.queryTimestamp;
-    delete newState.hideMast;
 
     return !ObjectUtils.deepEquals(currentState, newState);
   }
@@ -731,7 +727,6 @@ class Searcher extends React.Component<SearcherDefaultProps, SearcherProps, Sear
       debug,
       haveSearched: this.state.haveSearched, // Make sure we don't change this
       queryTimestamp: 0,
-      hideMast: this.state.hideMast, // Ignored as it does not apply to the search string
     };
 
     return result;


### PR DESCRIPTION
[PLAT-44338](https://jira.attivio.com/browse/PLAT-44338): Clicking Search should render SearchUI

This is a continuation https://github.com/attivio/suit/pull/158

The approach to store `hideMast` in Searcher is changed to pass in `simple` prop to `<Masthead>` if `/no-mast` is present in the URL. This is to separate the logic to read URLs from suit and should be rather passed as a prop from searchui. Thus in this case, `simple` prop needs to be passed to `<Masthead>` if a simplified version of the Masthead is to be rendered.

Additionally, `<SearchResultTags>` provides a way to navigate to the 360 Page if "Show 360° View" button is clicked. The URL for the 360 page is hardcoded here and should be changed to `/no-mast-doc360` if the simple masthead needs to be rendered. Thus, a new optional `url360Page` prop is passed to `<SearchResults>` which contains the URL for the 360 Page to be rendered.

Similarly, the page for Results is hardcoded and should be passed as a prop from searchui in `<Doc360Breadcrumbs>`.
