### PR TITLE
bug/PLAT-44229 : Fix to ensure center of map is correctly calculated

### DIFF
--- a/src/components/MapFacetContents.js
+++ b/src/components/MapFacetContents.js
@@ -63,9 +63,25 @@ class MapFacetContents extends React.Component<MapFacetContentsDefaultProps, Map
 
   static calcState(buckets: Array<SearchFacetBucket>, zoom: number,
     geoFilters: Array<string>, updating: string): MapFacetContentsState {
-    const center = PositionUtils.calcCenter(buckets.map((bucket) => {
-      return bucket.value;
-    }));
+    const center = PositionUtils.calcCenter(buckets.reduce((reduceResult, bucket) => {
+      const value = bucket.value;
+      let longitude = NaN;
+      let latitude = NaN;
+      if (typeof value === 'string') {
+        const valueArr = value.split(',');
+        if (valueArr.length === 2) {
+          longitude = Number.parseFloat(valueArr[0]);
+          latitude = Number.parseFloat(valueArr[1]);
+        }
+      } else {
+        longitude = value.longitude;
+        latitude = value.latitude;
+      }
+      if (!Number.isNaN(longitude) && !Number.isNaN(latitude)) {
+        reduceResult.push({ longitude, latitude });
+      }
+      return reduceResult;
+    }, []));
     return {
       latitude: center.latitude,
       longitude: center.longitude,

--- a/src/components/MapFacetContents.js
+++ b/src/components/MapFacetContents.js
@@ -79,7 +79,7 @@ class MapFacetContents extends React.Component<MapFacetContentsDefaultProps, Map
   }
 
   /**
-   * Fetches the latitude and longitude from the SearchFacetBucket value.
+   * Gets the latitude and longitude from the SearchFacetBucket value.
    * The SearchFacetBucket value returned from backend can have 2 different formats:
    * 1. Comma separated string. Eg. "22.56,17.53"
    * 2. Plain JS Object. Eg. { longitude: 22.56, latitude: 17.53 }

--- a/src/components/MapFacetContents.js
+++ b/src/components/MapFacetContents.js
@@ -63,25 +63,12 @@ class MapFacetContents extends React.Component<MapFacetContentsDefaultProps, Map
 
   static calcState(buckets: Array<SearchFacetBucket>, zoom: number,
     geoFilters: Array<string>, updating: string): MapFacetContentsState {
-    const center = PositionUtils.calcCenter(buckets.reduce((reduceResult, bucket) => {
-      const value = bucket.value;
-      let longitude = NaN;
-      let latitude = NaN;
-      if (typeof value === 'string') {
-        const valueArr = value.split(',');
-        if (valueArr.length === 2) {
-          longitude = Number.parseFloat(valueArr[0]);
-          latitude = Number.parseFloat(valueArr[1]);
-        }
-      } else {
-        longitude = value.longitude;
-        latitude = value.latitude;
-      }
-      if (!Number.isNaN(longitude) && !Number.isNaN(latitude)) {
-        reduceResult.push({ longitude, latitude });
-      }
-      return reduceResult;
-    }, []));
+    // Calculate the center from all the coordinates in the buckets.
+    // The output from map() is filtered to remove null values as
+    // getCoordinatesFromBucket() can return null.
+    const center = PositionUtils.calcCenter(buckets.map((bucket) => {
+      return MapFacetContents.getCoordinatesFromBucket(bucket);
+    }).filter(coordinates => coordinates !== null));
     return {
       latitude: center.latitude,
       longitude: center.longitude,
@@ -89,6 +76,33 @@ class MapFacetContents extends React.Component<MapFacetContentsDefaultProps, Map
       geoFilters,
       updating,
     };
+  }
+
+  /**
+   * Fetches the latitude and longitude from the SearchFacetBucket value.
+   * The SearchFacetBucket value returned from backend can have 2 different formats:
+   * 1. Comma separated string. Eg. "22.56,17.53"
+   * 2. Plain JS Object. Eg. { longitude: 22.56, latitude: 17.53 }
+   * This method returns null if bucket.value is different from these above 2 formats.
+   */
+  static getCoordinatesFromBucket(bucket: SearchFacetBucket):any {
+    const value = bucket.value;
+    let longitude = NaN;
+    let latitude = NaN;
+    if (typeof value === 'string') {
+      const valueArr = value.split(',');
+      if (valueArr.length === 2) {
+        longitude = Number.parseFloat(valueArr[0]);
+        latitude = Number.parseFloat(valueArr[1]);
+      }
+    } else {
+      longitude = value.longitude;
+      latitude = value.latitude;
+    }
+    if (Number.isNaN(longitude) || Number.isNaN(latitude)) {
+      return null;
+    }
+    return { longitude, latitude };
   }
 
   static getFilter(e: any): string {
@@ -215,22 +229,12 @@ class MapFacetContents extends React.Component<MapFacetContentsDefaultProps, Map
       });
 
       const points = this.props.buckets.map((bucket) => {
-        const value = bucket.value;
-        let longitude = NaN;
-        let latitude = NaN;
-        if (typeof value === 'string') {
-          const valueArr = value.split(',');
-          if (valueArr.length === 2) {
-            longitude = Number.parseFloat(valueArr[0]);
-            latitude = Number.parseFloat(valueArr[1]);
-          }
-        } else {
-          longitude = value.longitude;
-          latitude = value.latitude;
-        }
-        if (Number.isNaN(longitude) || Number.isNaN(latitude)) {
+        // Return null if getCoordinatesFromBucket() returns null value
+        const coordinates = MapFacetContents.getCoordinatesFromBucket(bucket);
+        if (!coordinates) {
           return null;
         }
+        const { longitude, latitude } = coordinates;
         // Keep track of the boundaries of the coordinates
         return (
           <Marker


### PR DESCRIPTION
[PLAT-44229 ](https://jira.attivio.com/browse/PLAT-44229) : Incorrect location pointer in Map facet in searchui

During testing of PLAT-44229, it was discovered that the center of the Map is not calculated correctly (https://jira.attivio.com/browse/PLAT-44229?focusedCommentId=481115&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-481115)

This bug was introduced in 5.6.1 as SearchFacetBucket.value returned from the backend API has the co-ordinates in string format `"<longitude>,<latitude>"`. However, UI expects value to be an object in the form of `{longitude: <longitude_value>, latitude: <latitude_value>}`.

Thus added support to convert the string value into the required format to fix this issue.