### PR TITLE
issue-35: Add pre-search hook to the SearchBar

### DIFF
--- a/documentation/components/SearchBar.md
+++ b/documentation/components/SearchBar.md
@@ -31,3 +31,21 @@ import { MemoryRouter } from 'react-router-dom';
     />
   </MemoryRouter>
 ```
+
+__4.__ Search bar with custom search hook.
+```jsx
+import { MemoryRouter } from 'react-router-dom';
+import DummySearcher from '../../src/components/DummySearcher';
+
+  <MemoryRouter>
+    <DummySearcher>
+      <SearchBar
+        searchHook={(query, searcher) => {
+          console.log('The searcher is: ', searcher);
+          alert(`The user wants to search for ${query}`);
+          return false; // Don't do the standard search behavior
+        }}
+      />
+    </DummySearcher>
+  </MemoryRouter>
+```


### PR DESCRIPTION
This allows applications to intercept the user's request to perform a search and do some alternative/additional logic.

The optional `searchHook` callback takes two parameters, the query string and the `Searcher` object. It can then do whatever it wants/needs to do.

If it has completely processed the query, it should return `false` to indicate that the `SearchBar` doesn't need to/shouldn't do anything else. If it returns true, then the standard processing of the query will still occur.

This PR is a replacement for PR 36